### PR TITLE
feat(apex): re-skin redbroomsoftware.com to light Palacio + shared shell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.0.0",
-        "@r-bsoftware/palacio-ui": "^0.1.0",
+        "@r-bsoftware/palacio-ui": "^0.1.1",
         "@sentry/sveltekit": "^10.38.0",
         "svelte-i18n": "^4.0.1"
       },
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/@r-bsoftware/palacio-ui": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@r-bsoftware/palacio-ui/0.1.0/63efd0f2360039b1c4d3b4663025ae6a3c03c7fd",
-      "integrity": "sha512-ZZ4eDo7GJii5XbLeTz/bKxmhvo0drs8jCfd7AP18k663eaOR7VF69G6NemVZ9F4XvUzyblWnlqbSq/fHOzasNQ==",
+      "version": "0.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@r-bsoftware/palacio-ui/0.1.1/3d8e026e75eec95753153150c80f9d425f4ba04a",
+      "integrity": "sha512-hdcMVdzGCGKdMwKX2s5Q+0lj+DkLIYrgj+0fsnggna7qJtjRpskFBU8txc1ht7xFOqDTQ5TuhwTo4XAs9pVLVg==",
       "license": "UNLICENSED",
       "peerDependencies": {
         "svelte": ">=5.0.0 <6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.0.0",
-        "@r-bsoftware/palacio-ui": "^0.0.1",
+        "@r-bsoftware/palacio-ui": "^0.1.0",
         "@sentry/sveltekit": "^10.38.0",
         "svelte-i18n": "^4.0.1"
       },
@@ -1528,10 +1528,13 @@
       }
     },
     "node_modules/@r-bsoftware/palacio-ui": {
-      "version": "0.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@r-bsoftware/palacio-ui/0.0.1/4c9963605313bf2e6fde3b6c1a3ed65f40f0067a",
-      "integrity": "sha512-shsI6NjX/focyt0U6+6aBcRn233U4MxEJjDwn/4L5qSdqrv2mr0zaemtv4QhtfJeJTwsYAHQAf2svEovV4FqMg==",
-      "license": "UNLICENSED"
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@r-bsoftware/palacio-ui/0.1.0/63efd0f2360039b1c4d3b4663025ae6a3c03c7fd",
+      "integrity": "sha512-ZZ4eDo7GJii5XbLeTz/bKxmhvo0drs8jCfd7AP18k663eaOR7VF69G6NemVZ9F4XvUzyblWnlqbSq/fHOzasNQ==",
+      "license": "UNLICENSED",
+      "peerDependencies": {
+        "svelte": ">=5.0.0 <6"
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "type": "module",
   "dependencies": {
     "@fontsource-variable/inter": "^5.0.0",
-    "@r-bsoftware/palacio-ui": "^0.1.0",
+    "@r-bsoftware/palacio-ui": "^0.1.1",
     "@sentry/sveltekit": "^10.38.0",
     "svelte-i18n": "^4.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "type": "module",
   "dependencies": {
     "@fontsource-variable/inter": "^5.0.0",
-    "@r-bsoftware/palacio-ui": "^0.0.1",
+    "@r-bsoftware/palacio-ui": "^0.1.0",
     "@sentry/sveltekit": "^10.38.0",
     "svelte-i18n": "^4.0.1"
   }

--- a/src/app.css
+++ b/src/app.css
@@ -10,18 +10,18 @@ html {
 }
 
 @layer utilities {
+	/* Light Palacio card surfaces — white bg + hairline border + subtle shadow.
+	   Replaces the former dark glassmorphism. Tokens-driven where possible. */
 	.glass {
-		background: rgba(15, 23, 42, 0.6);
-		backdrop-filter: blur(16px);
-		-webkit-backdrop-filter: blur(16px);
-		border: 1px solid rgba(148, 163, 184, 0.1);
+		background: #ffffff;
+		border: 1px solid var(--palacio-border-hairline);
+		box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 	}
 
 	.glass-strong {
-		background: rgba(15, 23, 42, 0.8);
-		backdrop-filter: blur(24px);
-		-webkit-backdrop-filter: blur(24px);
-		border: 1px solid rgba(148, 163, 184, 0.15);
+		background: #ffffff;
+		border: 1px solid var(--palacio-border-hairline);
+		box-shadow: 0 4px 16px rgba(15, 23, 42, 0.06);
 	}
 }
 
@@ -37,20 +37,20 @@ html {
 	transform: translateY(0);
 }
 
-/* Custom scrollbar */
+/* Custom scrollbar — light */
 ::-webkit-scrollbar {
 	width: 8px;
 }
 
 ::-webkit-scrollbar-track {
-	background: #0f172a;
+	background: #f3f4f6;
 }
 
 ::-webkit-scrollbar-thumb {
-	background: #334155;
+	background: #cbd5e1;
 	border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-	background: #475569;
+	background: #94a3b8;
 }

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<!-- TODO: apple-touch-icon should be a 180x180 PNG, not SVG -->
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/logo.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#0F172A" />
+		<meta name="theme-color" content="#ffffff" />
 		<meta name="author" content="Red Broom Software S.A.S. de C.V." />
 		%sveltekit.head%
 		<script src="https://camino.redbroomsoftware.com/sdk/camino-track.js" data-app="rbs-website" defer></script>

--- a/src/lib/components/ChatWidget.svelte
+++ b/src/lib/components/ChatWidget.svelte
@@ -147,7 +147,7 @@
 <!-- Floating Chat Button -->
 <button
   onclick={toggleChat}
-  class="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-blue-500 to-purple-600 text-white shadow-lg shadow-blue-500/25 transition-all duration-300 hover:scale-110 hover:shadow-xl hover:shadow-blue-500/40"
+  class="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-black text-white shadow-lg shadow-black/20 transition-all duration-300 hover:scale-110 hover:bg-gray-800"
   aria-label={isOpen ? $_('chat.closeChat') : $_('chat.openChat')}
 >
   {#if isOpen}
@@ -164,29 +164,29 @@
 <!-- Chat Panel -->
 {#if isOpen}
   <div
-    class="fixed z-50 flex flex-col overflow-hidden border border-slate-700/50 shadow-2xl shadow-black/50 transition-all duration-300 ease-in-out
+    class="fixed z-50 flex flex-col overflow-hidden border border-gray-200 shadow-2xl shadow-black/10 transition-all duration-300 ease-in-out
       max-sm:bottom-0 max-sm:right-0 max-sm:h-full max-sm:w-full max-sm:rounded-none
       sm:bottom-24 sm:right-6 sm:rounded-2xl
       {isExpanded ? 'sm:h-[calc(100vh-7rem)] sm:w-[520px]' : 'sm:h-[600px] sm:w-[420px]'}"
-    style="background: rgba(15, 23, 42, 0.95); backdrop-filter: blur(24px);"
+    style="background: #ffffff;"
   >
 
     <!-- Header -->
-    <div class="flex items-center gap-3 border-b border-slate-700/50 px-4 py-3">
-      <div class="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-r from-blue-500 to-purple-600">
+    <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+      <div class="flex h-9 w-9 items-center justify-center rounded-full bg-black">
         <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
         </svg>
       </div>
       <div class="flex-1">
-        <p class="text-sm font-semibold text-white">Red Broom Software</p>
-        <p class="text-xs text-slate-400">{$_('chat.salesAssistant')}</p>
+        <p class="text-sm font-semibold text-gray-900">Red Broom Software</p>
+        <p class="text-xs text-gray-500">{$_('chat.salesAssistant')}</p>
       </div>
       <div class="flex items-center gap-1">
         <!-- WhatsApp button -->
         <button
           onclick={openWhatsApp}
-          class="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-800 hover:text-green-400"
+          class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-green-600"
           title={$_('chat.continueWhatsApp')}
         >
           <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
@@ -196,7 +196,7 @@
         <!-- Expand/collapse button (desktop only) -->
         <button
           onclick={toggleExpand}
-          class="hidden rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-800 hover:text-white sm:block"
+          class="hidden rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-900 sm:block"
           title={isExpanded ? $_('chat.collapse') : $_('chat.expand')}
         >
           {#if isExpanded}
@@ -210,7 +210,7 @@
           {/if}
         </button>
         <!-- Close button (mobile) -->
-        <button onclick={toggleChat} class="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-800 hover:text-white sm:hidden">
+        <button onclick={toggleChat} class="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-900 sm:hidden">
           <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -219,19 +219,19 @@
     </div>
 
     <!-- Messages -->
-    <div bind:this={chatContainer} class="flex-1 overflow-y-auto px-4 py-3 space-y-3" style="scrollbar-width: thin; scrollbar-color: #334155 transparent;">
+    <div bind:this={chatContainer} class="flex-1 overflow-y-auto px-4 py-3 space-y-3" style="scrollbar-width: thin; scrollbar-color: #cbd5e1 transparent;">
       {#each messages as msg}
         <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
           <div class="max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed {msg.role === 'user'
-            ? 'bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-br-md'
-            : 'bg-slate-800/80 text-slate-200 rounded-bl-md border border-slate-700/30'}">
+            ? 'bg-black text-white rounded-br-md'
+            : 'bg-gray-100 text-gray-800 rounded-bl-md border border-gray-200'}">
             {#if msg.content}
               {msg.content}
             {:else}
               <span class="inline-flex gap-1">
-                <span class="h-2 w-2 animate-bounce rounded-full bg-slate-400" style="animation-delay: 0ms"></span>
-                <span class="h-2 w-2 animate-bounce rounded-full bg-slate-400" style="animation-delay: 150ms"></span>
-                <span class="h-2 w-2 animate-bounce rounded-full bg-slate-400" style="animation-delay: 300ms"></span>
+                <span class="h-2 w-2 animate-bounce rounded-full bg-gray-400" style="animation-delay: 0ms"></span>
+                <span class="h-2 w-2 animate-bounce rounded-full bg-gray-400" style="animation-delay: 150ms"></span>
+                <span class="h-2 w-2 animate-bounce rounded-full bg-gray-400" style="animation-delay: 300ms"></span>
               </span>
             {/if}
           </div>
@@ -240,7 +240,7 @@
     </div>
 
     <!-- Input -->
-    <div class="border-t border-slate-700/50 px-4 py-3">
+    <div class="border-t border-gray-100 px-4 py-3">
       <div class="flex items-center gap-2">
         <input
           type="text"
@@ -248,12 +248,12 @@
           onkeydown={handleKeydown}
           placeholder={$_('chat.placeholder')}
           disabled={isLoading}
-          class="flex-1 rounded-xl border border-slate-700 bg-slate-800/50 px-4 py-2.5 text-sm text-white placeholder-slate-500 outline-none transition-colors focus:border-blue-500 disabled:opacity-50"
+          class="flex-1 rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 outline-none transition-colors focus:border-gray-900 disabled:opacity-50"
         />
         <button
           onclick={sendMessage}
           disabled={isLoading || !inputText.trim()}
-          class="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-r from-blue-500 to-purple-600 text-white transition-all hover:shadow-lg hover:shadow-blue-500/25 disabled:opacity-50 disabled:hover:shadow-none"
+          class="flex h-10 w-10 items-center justify-center rounded-xl bg-black text-white transition-all hover:bg-gray-800 disabled:opacity-50"
         >
           <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
@@ -265,14 +265,14 @@
           href={WHATSAPP_URL}
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center gap-1.5 text-[11px] text-slate-500 transition-colors hover:text-green-400"
+          class="flex items-center gap-1.5 text-[11px] text-gray-400 transition-colors hover:text-green-600"
         >
           <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor">
             <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
           </svg>
           {$_('chat.continueWhatsApp')}
         </a>
-        <p class="text-[10px] text-slate-600">{$_('chat.poweredBy')}</p>
+        <p class="text-[10px] text-gray-400">{$_('chat.poweredBy')}</p>
       </div>
     </div>
   </div>

--- a/src/lib/components/EcosystemDiagram.svelte
+++ b/src/lib/components/EcosystemDiagram.svelte
@@ -33,15 +33,15 @@
 				class="glass rounded-xl p-3 text-center hover:scale-105 transition-transform cursor-default"
 				style="animation-delay: {i * 100}ms"
 			>
-				<div class="w-8 h-8 rounded-lg bg-gradient-to-r {app.color} mx-auto mb-1.5 opacity-80"></div>
-				<p class="text-white text-xs font-semibold">{app.name}</p>
-				<p class="text-slate-400 text-[10px]">{$_(`ecosystemDiagram.roles.${app.roleKey}`)}</p>
+				<div class="w-8 h-8 rounded-lg bg-gradient-to-r {app.color} mx-auto mb-1.5 opacity-90"></div>
+				<p class="text-gray-900 text-xs font-semibold">{app.name}</p>
+				<p class="text-gray-500 text-[10px]">{$_(`ecosystemDiagram.roles.${app.roleKey}`)}</p>
 			</div>
 		{/each}
 	</div>
 
 	<!-- Connection lines (decorative) -->
 	<div class="absolute inset-0 pointer-events-none overflow-hidden">
-		<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[400px] border border-slate-800/50 rounded-full"></div>
+		<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[400px] border border-gray-100 rounded-full"></div>
 	</div>
 </div>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -23,75 +23,75 @@
 </script>
 
 {#if full}
-	<footer class="border-t border-slate-800 py-16 px-4 sm:px-6 lg:px-8">
+	<footer class="border-t border-gray-100 py-16 px-4 sm:px-6 lg:px-8">
 		<div class="max-w-7xl mx-auto">
 			<div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-10">
 				<div>
 					<div class="flex items-center space-x-3 mb-4">
 						<img src="/logo.svg" alt={$_("common.companyName")} class="w-8 h-8" />
-						<span class="text-white font-bold">{$_("common.companyName")}</span>
+						<span class="text-gray-900 font-bold">{$_("common.companyName")}</span>
 					</div>
-					<p class="text-slate-400 text-sm mb-4">{$_("footer.description")}</p>
-					<a href="https://github.com/r-bsoftware" target="_blank" rel="noopener noreferrer" aria-label="GitHub" class="text-slate-500 hover:text-white transition-colors">
+					<p class="text-gray-600 text-sm mb-4">{$_("footer.description")}</p>
+					<a href="https://github.com/r-bsoftware" target="_blank" rel="noopener noreferrer" aria-label="GitHub" class="text-gray-400 hover:text-gray-900 transition-colors">
 						<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
 					</a>
 				</div>
 				<div>
-					<h4 class="text-white font-semibold mb-4">{$_("footer.services")}</h4>
+					<h4 class="text-gray-900 font-semibold mb-4">{$_("footer.services")}</h4>
 					<ul class="space-y-2 text-sm">
-						<li><a href="/servicios" class="text-slate-400 hover:text-white transition-colors">{$_("services.saas.title")}</a></li>
-						<li><a href="/servicios" class="text-slate-400 hover:text-white transition-colors">{$_("home.capabilities.pos.title")}</a></li>
-						<li><a href="/servicios" class="text-slate-400 hover:text-white transition-colors">{$_("home.capabilities.crm.title")}</a></li>
-						<li><a href="/servicios" class="text-slate-400 hover:text-white transition-colors">{$_("home.capabilities.mobile.title")}</a></li>
+						<li><a href="/servicios" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("services.saas.title")}</a></li>
+						<li><a href="/servicios" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("home.capabilities.pos.title")}</a></li>
+						<li><a href="/servicios" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("home.capabilities.crm.title")}</a></li>
+						<li><a href="/servicios" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("home.capabilities.mobile.title")}</a></li>
 					</ul>
 				</div>
 				<div>
-					<h4 class="text-white font-semibold mb-4">{$_("footer.company")}</h4>
+					<h4 class="text-gray-900 font-semibold mb-4">{$_("footer.company")}</h4>
 					<ul class="space-y-2 text-sm">
-						<li><a href="/portafolio" class="text-slate-400 hover:text-white transition-colors">{$_("nav.portfolio")}</a></li>
-						<li><a href="/tecnologia" class="text-slate-400 hover:text-white transition-colors">{$_("nav.technology")}</a></li>
-						<li><a href="/contacto" class="text-slate-400 hover:text-white transition-colors">{$_("nav.contact")}</a></li>
-						<li><a href="https://developers.redbroomsoftware.com" target="_blank" rel="noopener noreferrer" class="text-slate-400 hover:text-white transition-colors">{$_("nav.developers")}</a></li>
+						<li><a href="/portafolio" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("nav.portfolio")}</a></li>
+						<li><a href="/tecnologia" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("nav.technology")}</a></li>
+						<li><a href="/contacto" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("nav.contact")}</a></li>
+						<li><a href="https://developers.redbroomsoftware.com" target="_blank" rel="noopener noreferrer" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("nav.developers")}</a></li>
 					</ul>
 				</div>
 				<div>
-					<h4 class="text-white font-semibold mb-4">{$_("footer.legal")}</h4>
+					<h4 class="text-gray-900 font-semibold mb-4">{$_("footer.legal")}</h4>
 					<ul class="space-y-2 text-sm">
-						<li><a href="/privacidad" class="text-slate-400 hover:text-white transition-colors">{$_("nav.privacy")}</a></li>
-						<li><a href="/terminos" class="text-slate-400 hover:text-white transition-colors">{$_("nav.terms")}</a></li>
+						<li><a href="/privacidad" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("nav.privacy")}</a></li>
+						<li><a href="/terminos" class="text-gray-600 hover:text-gray-900 transition-colors">{$_("nav.terms")}</a></li>
 					</ul>
 				</div>
 			</div>
 
 			<!-- Ecosystem strip -->
-			<div class="border-t border-slate-800 pt-6 mb-6">
-				<p class="text-xs text-slate-500 mb-3">{$_("common.companyName")} {$_("footer.ecosystem")}</p>
+			<div class="border-t border-gray-100 pt-6 mb-6">
+				<p class="text-xs text-gray-400 mb-3">{$_("common.companyName")} {$_("footer.ecosystem")}</p>
 				<div class="flex flex-wrap gap-2">
 					{#each ecosystemApps as app, i}
-						<a href={app.url} target="_blank" rel="noopener noreferrer" class="text-xs text-slate-500 hover:text-slate-300 transition-colors">{app.name}</a>
+						<a href={app.url} target="_blank" rel="noopener noreferrer" class="text-xs text-gray-400 hover:text-gray-900 transition-colors">{app.name}</a>
 						{#if i !== ecosystemApps.length - 1}
-							<span class="text-slate-700">·</span>
+							<span class="text-gray-300">·</span>
 						{/if}
 					{/each}
 				</div>
 			</div>
 
-			<div class="border-t border-slate-800 pt-8 flex flex-col md:flex-row items-center justify-between gap-4">
-				<p class="text-slate-500 text-sm">&copy; {new Date().getFullYear()} {$_("footer.copyright")}</p>
-				<a href="mailto:dia@redbroomsoftware.com" class="text-slate-400 hover:text-white text-sm transition-colors">
+			<div class="border-t border-gray-100 pt-8 flex flex-col md:flex-row items-center justify-between gap-4">
+				<p class="text-gray-400 text-sm">&copy; {new Date().getFullYear()} {$_("footer.copyright")}</p>
+				<a href="mailto:dia@redbroomsoftware.com" class="text-gray-600 hover:text-gray-900 text-sm transition-colors">
 					dia@redbroomsoftware.com
 				</a>
 			</div>
 		</div>
 	</footer>
 {:else}
-	<footer class="border-t border-slate-800 py-8 px-4">
+	<footer class="border-t border-gray-100 py-8 px-4">
 		<div class="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-			<p class="text-slate-500 text-sm">&copy; {new Date().getFullYear()} {$_('footer.copyright')}</p>
+			<p class="text-gray-400 text-sm">&copy; {new Date().getFullYear()} {$_('footer.copyright')}</p>
 			<div class="flex items-center gap-6">
-				<a href="/privacidad" class="text-slate-500 hover:text-slate-300 text-sm">{$_("nav.privacy")}</a>
-				<a href="/terminos" class="text-slate-500 hover:text-slate-300 text-sm">{$_("nav.terms")}</a>
-				<a href="mailto:dia@redbroomsoftware.com" class="text-slate-400 hover:text-white text-sm transition-colors">
+				<a href="/privacidad" class="text-gray-400 hover:text-gray-900 text-sm">{$_("nav.privacy")}</a>
+				<a href="/terminos" class="text-gray-400 hover:text-gray-900 text-sm">{$_("nav.terms")}</a>
+				<a href="mailto:dia@redbroomsoftware.com" class="text-gray-600 hover:text-gray-900 text-sm transition-colors">
 					dia@redbroomsoftware.com
 				</a>
 			</div>

--- a/src/lib/components/TypewriterText.svelte
+++ b/src/lib/components/TypewriterText.svelte
@@ -28,4 +28,4 @@
 	});
 </script>
 
-<span class="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">{currentText}</span><span class="animate-pulse text-blue-400">|</span>
+<span class="text-gray-900">{currentText}</span><span class="animate-pulse text-gray-400">|</span>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,9 @@
-<script>
+<script lang="ts">
 	import '../app.css';
 	import { getStoredLocale, setLocale } from '$lib/i18n';
 	import { onMount } from 'svelte';
-	import Header from '$lib/components/Header.svelte';
+	import { _, locale } from 'svelte-i18n';
+	import { SiteHeader, SiteFooter } from '@r-bsoftware/palacio-ui';
 
 	let { children } = $props();
 
@@ -10,13 +11,34 @@
 		const stored = getStoredLocale();
 		if (stored) setLocale(stored);
 	});
+
+	// Shared shell expects a narrowed 'es' | 'en'; default anything else to 'es'.
+	const shellLocale = $derived(($locale === 'en' ? 'en' : 'es') as 'es' | 'en');
+
+	// Bridge the shared shell's (key, fallback) translator to svelte-i18n.
+	// $_ returns the key itself when a key is missing, so fall back in that case.
+	function shellT(key: string, fallback: string): string {
+		const v = $_(key);
+		return v === key ? fallback : v;
+	}
+
+	function onLocaleChange(l: 'es' | 'en') {
+		setLocale(l);
+	}
 </script>
 
-<!-- accent-rbs mounts the apex's Palacio Engine accent so future Palacio-themed
-     sections (4-function cards CTAs, signing previews) inherit the apex tone. -->
-<div class="min-h-screen bg-slate-950 accent-rbs">
-	<Header />
-	<main id="main">
+<!-- accent-rbs mounts the apex's Palacio Engine accent (black) so the shared shell
+     and any Palacio-themed sections inherit the apex tone. Light surface throughout. -->
+<div class="min-h-screen flex flex-col bg-white text-gray-900 accent-rbs">
+	<SiteHeader
+		surface="rbs"
+		locale={shellLocale}
+		{onLocaleChange}
+		t={shellT}
+		ctaLabel={shellT('nav.contact', 'Empezar')}
+	/>
+	<main id="main" class="flex-1">
 		{@render children()}
 	</main>
+	<SiteFooter surface="rbs" locale={shellLocale} />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -74,31 +74,28 @@
 
 <!-- Hero -->
 	<section class="relative py-28 px-4 sm:px-6 lg:px-8 overflow-hidden">
-		<div class="absolute inset-0 bg-gradient-to-b from-blue-600/10 via-purple-600/5 to-transparent"></div>
-		<div class="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[800px] bg-gradient-to-r from-blue-500/15 to-purple-500/15 rounded-full blur-3xl animate-glow"></div>
-
 		<div class="max-w-7xl mx-auto text-center relative">
-			<div class="inline-flex items-center px-4 py-2 glass rounded-full text-sm text-slate-300 mb-8">
-				<span class="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
+			<div class="inline-flex items-center px-4 py-2 glass rounded-full text-sm text-gray-600 mb-8">
+				<span class="w-2 h-2 bg-emerald-500 rounded-full mr-2 animate-pulse"></span>
 				{$_('home.hero.badge')}
 			</div>
 
-			<h1 class="text-5xl md:text-7xl font-bold text-white mb-6 leading-tight">
+			<h1 class="text-5xl md:text-7xl font-bold text-gray-900 mb-6 leading-tight tracking-tight">
 				{$_('home.hero.titlePart1')}<br />
 				<TypewriterText words={[$_('home.hero.typewriterWords.0'), $_('home.hero.typewriterWords.1'), $_('home.hero.typewriterWords.2'), $_('home.hero.typewriterWords.3')]} interval={2500} />
 				<br />
-				<span class="text-slate-300">{$_('home.hero.forGlobalBusiness')}</span>
+				<span class="text-gray-500">{$_('home.hero.forGlobalBusiness')}</span>
 			</h1>
 
-			<p class="text-xl text-slate-400 mb-10 max-w-3xl mx-auto leading-relaxed">
+			<p class="text-xl text-gray-600 mb-10 max-w-3xl mx-auto leading-relaxed">
 				{$_('home.hero.subtitle')}
 			</p>
 
 			<div class="flex flex-col sm:flex-row gap-4 justify-center">
-				<a href="https://patadas.redbroomsoftware.com/get-started" target="_blank" rel="noopener noreferrer" class="px-8 py-4 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl hover:from-orange-600 hover:to-orange-700 transition-all text-lg font-semibold shadow-lg shadow-orange-500/25 hover:shadow-xl hover:-translate-y-0.5">
+				<a href="https://patadas.redbroomsoftware.com/get-started" target="_blank" rel="noopener noreferrer" class="px-8 py-4 bg-black text-white rounded-xl hover:bg-gray-800 transition-all text-lg font-semibold hover:-translate-y-0.5">
 					{$_('home.cta.findSolution')}
 				</a>
-				<a href="https://patadas.redbroomsoftware.com/developers/apply" target="_blank" rel="noopener noreferrer" class="px-8 py-4 glass text-white rounded-xl hover:bg-slate-800/80 transition-all text-lg font-semibold">
+				<a href="https://patadas.redbroomsoftware.com/developers/apply" target="_blank" rel="noopener noreferrer" class="px-8 py-4 bg-white text-gray-900 border border-gray-300 rounded-xl hover:border-gray-900 transition-all text-lg font-semibold">
 					{$_('home.cta.joinDeveloper')}
 				</a>
 			</div>
@@ -106,30 +103,30 @@
 			<!-- Stats -->
 			<div class="grid grid-cols-2 sm:grid-cols-4 gap-8 mt-20 max-w-3xl mx-auto">
 				<div>
-					<p class="text-4xl font-bold text-white"><AnimatedCounter value={22} /></p>
-					<p class="text-slate-400 text-sm">{$_('home.stats.apps')}</p>
+					<p class="text-4xl font-bold text-gray-900"><AnimatedCounter value={22} /></p>
+					<p class="text-gray-500 text-sm">{$_('home.stats.apps')}</p>
 				</div>
 				<div>
-					<p class="text-4xl font-bold text-white"><AnimatedCounter value={10} suffix="+" /></p>
-					<p class="text-slate-400 text-sm">{$_('home.stats.industries')}</p>
+					<p class="text-4xl font-bold text-gray-900"><AnimatedCounter value={10} suffix="+" /></p>
+					<p class="text-gray-500 text-sm">{$_('home.stats.industries')}</p>
 				</div>
 				<div>
-					<p class="text-4xl font-bold text-white">1</p>
-					<p class="text-slate-400 text-sm">{$_('home.stats.sdk')}</p>
+					<p class="text-4xl font-bold text-gray-900">1</p>
+					<p class="text-gray-500 text-sm">{$_('home.stats.sdk')}</p>
 				</div>
 				<div>
-					<p class="text-4xl font-bold text-white">2</p>
-					<p class="text-slate-400 text-sm">{$_('home.stats.languages')}</p>
+					<p class="text-4xl font-bold text-gray-900">2</p>
+					<p class="text-gray-500 text-sm">{$_('home.stats.languages')}</p>
 				</div>
 			</div>
 		</div>
 	</section>
 
 	<!-- Tech Marquee -->
-	<section class="py-8 overflow-hidden border-y border-slate-800/50">
+	<section class="py-8 overflow-hidden border-y border-gray-100">
 		<div class="flex animate-marquee whitespace-nowrap">
 			{#each [...techLogos, ...techLogos] as logo}
-				<span class="mx-8 text-slate-500 text-sm font-medium">{logo}</span>
+				<span class="mx-8 text-gray-400 text-sm font-medium">{logo}</span>
 			{/each}
 		</div>
 	</section>
@@ -139,12 +136,12 @@
 		<div class="max-w-5xl mx-auto">
 			<div class="glass-strong rounded-3xl p-8 md:p-12 text-center" use:scrollReveal>
 				<div class="text-5xl mb-4">⚡</div>
-				<h2 class="text-3xl md:text-4xl font-bold text-white mb-4">{$_('home.patadas.title')}</h2>
-				<p class="text-xl text-slate-300 mb-2">{$_('home.patadas.subtitle')}</p>
-				<p class="text-slate-400 max-w-2xl mx-auto mb-8">
+				<h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">{$_('home.patadas.title')}</h2>
+				<p class="text-xl text-gray-700 mb-2">{$_('home.patadas.subtitle')}</p>
+				<p class="text-gray-600 max-w-2xl mx-auto mb-8">
 					{$_('home.patadas.description')}
 				</p>
-				<a href="https://patadas.redbroomsoftware.com" target="_blank" rel="noopener noreferrer" class="inline-flex px-8 py-4 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl hover:from-orange-600 hover:to-orange-700 transition-all text-lg font-semibold shadow-lg shadow-orange-500/25 hover:shadow-xl hover:-translate-y-0.5">
+				<a href="https://patadas.redbroomsoftware.com" target="_blank" rel="noopener noreferrer" class="inline-flex px-8 py-4 bg-black text-white rounded-xl hover:bg-gray-800 transition-all text-lg font-semibold hover:-translate-y-0.5">
 					{$_('home.patadas.button')} →
 				</a>
 			</div>
@@ -152,11 +149,11 @@
 	</section>
 
 	<!-- Cuatro Funciones — apex mirror of Palacio's lupa (Forge/Patadas/Labs/Atlas) -->
-	<section class="py-24 px-4 sm:px-6 lg:px-8 bg-slate-900/50">
+	<section class="py-24 px-4 sm:px-6 lg:px-8 bg-gray-50">
 		<div class="max-w-7xl mx-auto">
 			<div class="text-center mb-16 max-w-3xl mx-auto" use:scrollReveal>
-				<h2 class="text-4xl font-bold text-white mb-4">{$_('home.functions.title')}</h2>
-				<p class="text-xl text-slate-400">
+				<h2 class="text-4xl font-bold text-gray-900 mb-4">{$_('home.functions.title')}</h2>
+				<p class="text-xl text-gray-600">
 					{$_('home.functions.subtitle')}
 				</p>
 			</div>
@@ -168,13 +165,13 @@
 						target="_blank"
 						rel="noopener noreferrer"
 						use:scrollReveal={{ delay: i * 100 }}
-						class="glass rounded-2xl p-8 hover:border-blue-500/50 transition-all group block"
+						class="glass rounded-2xl p-8 hover:border-gray-900 transition-all group block"
 					>
 						<div class="text-4xl mb-4">{fn.icon}</div>
-						<h3 class="text-xs font-semibold tracking-widest uppercase text-slate-500 mb-2">{$_(`home.functions.${fn.key}.tagline`)}</h3>
-						<p class="text-2xl font-bold text-white mb-3">{$_(`home.functions.${fn.key}.title`)}</p>
-						<p class="text-slate-400 leading-relaxed text-sm">{$_(`home.functions.${fn.key}.desc`)}</p>
-						<p class="mt-6 text-xs font-semibold uppercase tracking-wider text-slate-500 group-hover:text-white transition-colors">
+						<h3 class="text-xs font-semibold tracking-widest uppercase text-gray-400 mb-2">{$_(`home.functions.${fn.key}.tagline`)}</h3>
+						<p class="text-2xl font-bold text-gray-900 mb-3">{$_(`home.functions.${fn.key}.title`)}</p>
+						<p class="text-gray-600 leading-relaxed text-sm">{$_(`home.functions.${fn.key}.desc`)}</p>
+						<p class="mt-6 text-xs font-semibold uppercase tracking-wider text-gray-400 group-hover:text-gray-900 transition-colors">
 							{$_(`home.functions.${fn.key}.cta`)} →
 						</p>
 					</a>
@@ -187,22 +184,22 @@
 	<section class="py-24 px-4 sm:px-6 lg:px-8">
 		<div class="max-w-7xl mx-auto">
 			<div class="text-center mb-16" use:scrollReveal>
-				<h2 class="text-4xl font-bold text-white mb-4">{$_('home.ecosystem.title')}</h2>
-				<p class="text-xl text-slate-400">{$_('home.ecosystem.subtitle')}</p>
+				<h2 class="text-4xl font-bold text-gray-900 mb-4">{$_('home.ecosystem.title')}</h2>
+				<p class="text-xl text-gray-600">{$_('home.ecosystem.subtitle')}</p>
 			</div>
 
 			<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
 				{#each ecosystemAppKeys as app, i}
 					<div
 						use:scrollReveal={{ delay: i * 50 }}
-						class="glass rounded-xl p-5 hover:scale-[1.03] transition-all group"
+						class="glass rounded-xl p-5 hover:shadow-md transition-all group"
 					>
-						<div class="w-10 h-10 rounded-lg bg-gradient-to-r {app.gradient} mb-3 opacity-80 group-hover:opacity-100 transition-opacity"></div>
-						<span class="inline-block px-2 py-0.5 bg-slate-700/50 text-slate-400 rounded-full text-[10px] font-medium mb-2">
+						<div class="w-10 h-10 rounded-lg bg-gradient-to-r {app.gradient} mb-3 opacity-90 group-hover:opacity-100 transition-opacity"></div>
+						<span class="inline-block px-2 py-0.5 bg-gray-100 text-gray-500 rounded-full text-[10px] font-medium mb-2">
 							{$_(`home.ecosystem.apps.${app.key}.badge`)}
 						</span>
-						<h3 class="text-lg font-bold text-white">{$_(`home.ecosystem.apps.${app.key}.name`)}</h3>
-						<p class="text-slate-400 text-sm">{$_(`home.ecosystem.apps.${app.key}.desc`)}</p>
+						<h3 class="text-lg font-bold text-gray-900">{$_(`home.ecosystem.apps.${app.key}.name`)}</h3>
+						<p class="text-gray-600 text-sm">{$_(`home.ecosystem.apps.${app.key}.desc`)}</p>
 					</div>
 				{/each}
 			</div>
@@ -210,11 +207,11 @@
 	</section>
 
 	<!-- Ecosystem Diagram -->
-	<section class="py-24 px-4 sm:px-6 lg:px-8 bg-slate-900/50">
+	<section class="py-24 px-4 sm:px-6 lg:px-8 bg-gray-50">
 		<div class="max-w-5xl mx-auto">
 			<div class="text-center mb-12" use:scrollReveal>
-				<h2 class="text-4xl font-bold text-white mb-4">{$_('home.ecosystemDiagram.title')}</h2>
-				<p class="text-xl text-slate-400">{$_('home.ecosystemDiagram.subtitle')}</p>
+				<h2 class="text-4xl font-bold text-gray-900 mb-4">{$_('home.ecosystemDiagram.title')}</h2>
+				<p class="text-xl text-gray-600">{$_('home.ecosystemDiagram.subtitle')}</p>
 			</div>
 			<div use:scrollReveal>
 				<EcosystemDiagram />
@@ -224,17 +221,16 @@
 
 	<!-- Final CTA -->
 	<section class="py-24 px-4 sm:px-6 lg:px-8 relative overflow-hidden">
-		<div class="absolute inset-0 bg-gradient-to-r from-orange-600/5 via-purple-600/5 to-orange-600/5"></div>
 		<div class="max-w-4xl mx-auto text-center relative" use:scrollReveal>
-			<h2 class="text-4xl font-bold text-white mb-6">{$_('home.finalCta.title')}</h2>
-			<p class="text-xl text-slate-400 mb-10">
+			<h2 class="text-4xl font-bold text-gray-900 mb-6">{$_('home.finalCta.title')}</h2>
+			<p class="text-xl text-gray-600 mb-10">
 				{$_('home.finalCta.subtitle')}
 			</p>
 			<div class="flex flex-col sm:flex-row gap-4 justify-center">
-				<a href="https://patadas.redbroomsoftware.com/get-started" target="_blank" rel="noopener noreferrer" class="px-10 py-5 bg-gradient-to-r from-orange-500 to-orange-600 text-white rounded-xl hover:from-orange-600 hover:to-orange-700 transition-all text-lg font-semibold shadow-lg shadow-orange-500/25 hover:shadow-xl hover:-translate-y-0.5">
+				<a href="https://patadas.redbroomsoftware.com/get-started" target="_blank" rel="noopener noreferrer" class="px-10 py-5 bg-black text-white rounded-xl hover:bg-gray-800 transition-all text-lg font-semibold hover:-translate-y-0.5">
 					{$_('home.finalCta.findSolution')}
 				</a>
-				<a href="mailto:dia@redbroomsoftware.com" class="px-10 py-5 glass text-white rounded-xl hover:bg-slate-800/80 transition-all text-lg font-semibold">
+				<a href="mailto:dia@redbroomsoftware.com" class="px-10 py-5 bg-white text-gray-900 border border-gray-300 rounded-xl hover:border-gray-900 transition-all text-lg font-semibold">
 					{$_('home.finalCta.directContact')}
 				</a>
 			</div>

--- a/src/routes/contacto/+page.svelte
+++ b/src/routes/contacto/+page.svelte
@@ -147,12 +147,11 @@
 
 <!-- Hero -->
 <section class="py-20 px-4 sm:px-6 lg:px-8 relative">
-	<div class="absolute inset-0 bg-gradient-to-b from-blue-600/10 via-transparent to-transparent"></div>
 	<div class="max-w-7xl mx-auto text-center relative">
-		<h2 class="text-4xl md:text-6xl font-bold text-white mb-6">
-			{$_('contact.hero.titlePart1')} <span class="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">{$_('contact.hero.titleHighlight')}</span>
+		<h2 class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 tracking-tight">
+			{$_('contact.hero.titlePart1')} <span class="text-gray-500">{$_('contact.hero.titleHighlight')}</span>
 		</h2>
-		<p class="text-xl text-slate-400 max-w-2xl mx-auto">
+		<p class="text-xl text-gray-600 max-w-2xl mx-auto">
 			{$_('contact.hero.subtitle')}
 		</p>
 	</div>
@@ -166,16 +165,16 @@
 			<div use:scrollReveal class="glass-strong rounded-2xl p-8">
 				{#if submitStatus === 'success'}
 					<div class="text-center py-12">
-						<div class="w-16 h-16 bg-emerald-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
-							<svg class="w-8 h-8 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<div class="w-16 h-16 bg-emerald-50 rounded-full flex items-center justify-center mx-auto mb-4">
+							<svg class="w-8 h-8 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
 							</svg>
 						</div>
-						<h3 class="text-2xl font-bold text-white mb-2">{$_('contact.form.successTitle')}</h3>
-						<p class="text-slate-400">{$_('contact.form.successMessage')}</p>
+						<h3 class="text-2xl font-bold text-gray-900 mb-2">{$_('contact.form.successTitle')}</h3>
+						<p class="text-gray-600">{$_('contact.form.successMessage')}</p>
 					</div>
 				{:else}
-					<h3 class="text-2xl font-bold text-white mb-6">{$_('contact.form.title')}</h3>
+					<h3 class="text-2xl font-bold text-gray-900 mb-6">{$_('contact.form.title')}</h3>
 					<form onsubmit={handleContactSubmit} class="space-y-6">
 						<!-- Honeypot: invisible to humans, bots auto-fill it -->
 						<div aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;height:0;overflow:hidden;opacity:0;">
@@ -184,54 +183,54 @@
 						</div>
 						<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 							<div>
-								<label for="name" class="block text-sm text-slate-400 mb-2">{$_("contact.form.nameLabel")} {$_("contact.form.required")}</label>
+								<label for="name" class="block text-sm text-gray-600 mb-2">{$_("contact.form.nameLabel")} {$_("contact.form.required")}</label>
 								<input
 									type="text"
 									id="name"
 									bind:value={contactForm.name}
 									required
-									class="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:border-blue-500 focus:outline-none"
+									class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:border-gray-900 focus:outline-none"
 								/>
 							</div>
 							<div>
-								<label for="email" class="block text-sm text-slate-400 mb-2">{$_("contact.form.emailLabel")} {$_("contact.form.required")}</label>
+								<label for="email" class="block text-sm text-gray-600 mb-2">{$_("contact.form.emailLabel")} {$_("contact.form.required")}</label>
 								<input
 									type="email"
 									id="email"
 									bind:value={contactForm.email}
 									required
-									class="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:border-blue-500 focus:outline-none"
+									class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:border-gray-900 focus:outline-none"
 								/>
 							</div>
 						</div>
 
 						<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 							<div>
-								<label for="company" class="block text-sm text-slate-400 mb-2">{$_("contact.form.companyLabel")}</label>
+								<label for="company" class="block text-sm text-gray-600 mb-2">{$_("contact.form.companyLabel")}</label>
 								<input
 									type="text"
 									id="company"
 									bind:value={contactForm.company}
-									class="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:border-blue-500 focus:outline-none"
+									class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:border-gray-900 focus:outline-none"
 								/>
 							</div>
 							<div>
-								<label for="phone" class="block text-sm text-slate-400 mb-2">{$_("contact.form.phoneLabel")}</label>
+								<label for="phone" class="block text-sm text-gray-600 mb-2">{$_("contact.form.phoneLabel")}</label>
 								<input
 									type="tel"
 									id="phone"
 									bind:value={contactForm.phone}
-									class="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:border-blue-500 focus:outline-none"
+									class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:border-gray-900 focus:outline-none"
 								/>
 							</div>
 						</div>
 
 						<div>
-							<label for="projectType" class="block text-sm text-slate-400 mb-2">{$_("contact.form.projectTypeLabel")}</label>
+							<label for="projectType" class="block text-sm text-gray-600 mb-2">{$_("contact.form.projectTypeLabel")}</label>
 							<select
 								id="projectType"
 								bind:value={contactForm.projectType}
-								class="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:border-blue-500 focus:outline-none"
+								class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:border-gray-900 focus:outline-none"
 							>
 								<option value="">{$_("contact.form.selectOption")}</option>
 								{#each projectTypeKeys as key}
@@ -241,19 +240,19 @@
 						</div>
 
 						<div>
-							<label for="message" class="block text-sm text-slate-400 mb-2">{$_("contact.form.messageLabel")} {$_("contact.form.required")}</label>
+							<label for="message" class="block text-sm text-gray-600 mb-2">{$_("contact.form.messageLabel")} {$_("contact.form.required")}</label>
 							<textarea
 								id="message"
 								bind:value={contactForm.message}
 								required
 								rows="4"
-								class="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:border-blue-500 focus:outline-none resize-none"
+								class="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-gray-900 focus:border-gray-900 focus:outline-none resize-none"
 								placeholder={$_("contact.form.messagePlaceholder")}
 							></textarea>
 						</div>
 
 						{#if submitStatus === 'error'}
-							<div class="bg-red-500/20 border border-red-500/50 rounded-lg p-4 text-red-400 text-sm">
+							<div class="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 text-sm">
 								{errorMessage}
 							</div>
 						{/if}
@@ -261,7 +260,7 @@
 						<button
 							type="submit"
 							disabled={submitStatus === 'submitting'}
-							class="w-full px-6 py-4 bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-lg hover:from-blue-600 hover:to-purple-700 transition-all font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+							class="w-full px-6 py-4 bg-black text-white rounded-lg hover:bg-gray-800 transition-all font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
 						>
 							{submitStatus === 'submitting' ? $_('contact.form.submitting') : $_('contact.form.submitButton')}
 						</button>
@@ -272,36 +271,36 @@
 			<!-- Info -->
 			<div class="space-y-8" use:scrollReveal={{ delay: 200 }}>
 				<div>
-					<h3 class="text-2xl font-bold text-white mb-4">{$_('contact.process.title')}</h3>
+					<h3 class="text-2xl font-bold text-gray-900 mb-4">{$_('contact.process.title')}</h3>
 					<div class="space-y-4">
 						<div class="flex items-start gap-4">
-							<div class="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">1</div>
+							<div class="w-8 h-8 bg-black rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">1</div>
 							<div>
-								<h4 class="text-white font-semibold">{$_('contact.process.step1.title')}</h4>
-								<p class="text-slate-400 text-sm">{$_('contact.process.step1.desc')}</p>
+								<h4 class="text-gray-900 font-semibold">{$_('contact.process.step1.title')}</h4>
+								<p class="text-gray-600 text-sm">{$_('contact.process.step1.desc')}</p>
 							</div>
 						</div>
 						<div class="flex items-start gap-4">
-							<div class="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">2</div>
+							<div class="w-8 h-8 bg-black rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">2</div>
 							<div>
-								<h4 class="text-white font-semibold">{$_('contact.process.step2.title')}</h4>
-								<p class="text-slate-400 text-sm">{$_('contact.process.step2.desc')}</p>
+								<h4 class="text-gray-900 font-semibold">{$_('contact.process.step2.title')}</h4>
+								<p class="text-gray-600 text-sm">{$_('contact.process.step2.desc')}</p>
 							</div>
 						</div>
 						<div class="flex items-start gap-4">
-							<div class="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">3</div>
+							<div class="w-8 h-8 bg-black rounded-full flex items-center justify-center text-white font-bold flex-shrink-0">3</div>
 							<div>
-								<h4 class="text-white font-semibold">{$_('contact.process.step3.title')}</h4>
-								<p class="text-slate-400 text-sm">{$_('contact.process.step3.desc')}</p>
+								<h4 class="text-gray-900 font-semibold">{$_('contact.process.step3.title')}</h4>
+								<p class="text-gray-600 text-sm">{$_('contact.process.step3.desc')}</p>
 							</div>
 						</div>
 					</div>
 				</div>
 
 				<div class="glass rounded-2xl p-6">
-					<h4 class="text-white font-semibold mb-4">{$_('contact.directContact.title')}</h4>
+					<h4 class="text-gray-900 font-semibold mb-4">{$_('contact.directContact.title')}</h4>
 					<div class="space-y-3">
-						<a href="mailto:dia@redbroomsoftware.com" class="flex items-center gap-3 text-slate-400 hover:text-white transition-colors">
+						<a href="mailto:dia@redbroomsoftware.com" class="flex items-center gap-3 text-gray-600 hover:text-gray-900 transition-colors">
 							<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
 							</svg>
@@ -310,9 +309,9 @@
 					</div>
 				</div>
 
-				<div class="bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-2xl border border-blue-500/20 p-6">
-					<h4 class="text-white font-semibold mb-2">{$_('contact.urgent.title')}</h4>
-					<p class="text-slate-400 text-sm mb-4">{$_('contact.urgent.desc')}</p>
+				<div class="bg-gray-50 rounded-2xl border border-gray-200 p-6">
+					<h4 class="text-gray-900 font-semibold mb-2">{$_('contact.urgent.title')}</h4>
+					<p class="text-gray-600 text-sm mb-4">{$_('contact.urgent.desc')}</p>
 				</div>
 			</div>
 		</div>

--- a/src/routes/plataformas/+page.svelte
+++ b/src/routes/plataformas/+page.svelte
@@ -176,18 +176,20 @@
 	}
 
 	// Color map for Tailwind (static classes for purging)
+	// Palacio re-skin: pricing text reads as strong black on light; cards share a uniform
+	// hairline → gray-900 hover. The per-app color key is retained (used by c()) but maps to neutral.
 	const colors = {
-		amber:  { text: 'text-amber-400',  border: 'hover:border-amber-500/50',  shadow: 'hover:shadow-amber-500/10' },
-		rose:   { text: 'text-rose-400',   border: 'hover:border-rose-500/50',   shadow: 'hover:shadow-rose-500/10' },
-		purple: { text: 'text-purple-400', border: 'hover:border-purple-500/50', shadow: 'hover:shadow-purple-500/10' },
-		teal:   { text: 'text-teal-400',   border: 'hover:border-teal-500/50',   shadow: 'hover:shadow-teal-500/10' },
-		indigo: { text: 'text-indigo-400', border: 'hover:border-indigo-500/50', shadow: 'hover:shadow-indigo-500/10' },
-		sky:    { text: 'text-sky-400',    border: 'hover:border-sky-500/50',    shadow: 'hover:shadow-sky-500/10' },
-		lime:   { text: 'text-lime-400',   border: 'hover:border-lime-500/50',   shadow: 'hover:shadow-lime-500/10' },
-		orange: { text: 'text-orange-400', border: 'hover:border-orange-500/50', shadow: 'hover:shadow-orange-500/10' },
-		cyan:   { text: 'text-cyan-400',   border: 'hover:border-cyan-500/50',   shadow: 'hover:shadow-cyan-500/10' },
-		blue:   { text: 'text-blue-400',   border: 'hover:border-blue-500/50',   shadow: 'hover:shadow-blue-500/10' },
-		emerald:{ text: 'text-emerald-400',border: 'hover:border-emerald-500/50',shadow: 'hover:shadow-emerald-500/10' }
+		amber:  { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		rose:   { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		purple: { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		teal:   { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		indigo: { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		sky:    { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		lime:   { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		orange: { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		cyan:   { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		blue:   { text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' },
+		emerald:{ text: 'text-gray-900', border: 'hover:border-gray-900', shadow: 'hover:shadow-md' }
 	};
 
 	function c(color) { return colors[color] || colors.blue; }
@@ -208,19 +210,18 @@
 
 <!-- Hero -->
 <section class="py-20 px-4 sm:px-6 lg:px-8 relative">
-	<div class="absolute inset-0 bg-gradient-to-b from-blue-600/10 via-transparent to-transparent"></div>
 	<div class="max-w-7xl mx-auto text-center relative">
-		<h1 class="text-4xl md:text-6xl font-bold text-white mb-6" use:scrollReveal>
-			{heroData.title} <span class="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">{heroData.title_highlight}</span>
+		<h1 class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 tracking-tight" use:scrollReveal>
+			{heroData.title} <span class="text-gray-500">{heroData.title_highlight}</span>
 		</h1>
-		<p class="text-xl text-slate-400 max-w-3xl mx-auto mb-8" use:scrollReveal={{ delay: 100 }}>
+		<p class="text-xl text-gray-600 max-w-3xl mx-auto mb-8" use:scrollReveal={{ delay: 100 }}>
 			{heroData.subtitle}
 		</p>
 		<div class="flex flex-col sm:flex-row gap-4 justify-center" use:scrollReveal={{ delay: 200 }}>
-			<a href={heroData.cta_primary.href} class="bg-gradient-to-r from-blue-500 to-purple-600 text-white hover:from-blue-600 hover:to-purple-700 transition-all rounded-xl px-8 py-4 font-semibold shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40" data-camino-cta="hero-primary">
+			<a href={heroData.cta_primary.href} class="bg-black text-white hover:bg-gray-800 transition-all rounded-xl px-8 py-4 font-semibold" data-camino-cta="hero-primary">
 				{heroData.cta_primary.text}
 			</a>
-			<a href={heroData.cta_secondary.href} class="glass text-white hover:bg-slate-800/80 transition-all rounded-xl px-8 py-4 font-semibold" data-camino-cta="hero-secondary">
+			<a href={heroData.cta_secondary.href} class="bg-white text-gray-900 border border-gray-300 hover:border-gray-900 transition-all rounded-xl px-8 py-4 font-semibold" data-camino-cta="hero-secondary">
 				{heroData.cta_secondary.text}
 			</a>
 		</div>
@@ -230,19 +231,19 @@
 <!-- Bundle Discount Banner -->
 <section class="px-4 sm:px-6 lg:px-8 -mt-8 mb-16">
 	<div class="max-w-4xl mx-auto" use:scrollReveal={{ delay: 200 }}>
-		<div class="glass rounded-2xl p-6 md:p-8 border border-emerald-500/20">
+		<div class="glass rounded-2xl p-6 md:p-8">
 			<div class="flex flex-col md:flex-row items-center gap-6">
 				<div class="flex-1">
-					<h3 class="text-lg font-semibold text-white mb-2">
-						<span class="text-emerald-400">{bannerData.title}</span> — {bannerData.subtitle}
+					<h3 class="text-lg font-semibold text-gray-900 mb-2">
+						<span class="text-emerald-600">{bannerData.title}</span> — {bannerData.subtitle}
 					</h3>
-					<p class="text-slate-400 text-sm">{bannerData.description}</p>
+					<p class="text-gray-600 text-sm">{bannerData.description}</p>
 				</div>
 				<div class="flex gap-4">
 					{#each bannerData.items as item}
 						<div class="text-center">
-							<div class="text-2xl font-bold text-emerald-400">{item.value}</div>
-							<div class="text-xs text-slate-500">{item.label}</div>
+							<div class="text-2xl font-bold text-emerald-600">{item.value}</div>
+							<div class="text-xs text-gray-500">{item.label}</div>
 						</div>
 					{/each}
 				</div>
@@ -255,8 +256,8 @@
 <section id="plataformas" class="py-16 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-7xl mx-auto">
 		<div class="mb-10" use:scrollReveal>
-			<h2 class="text-3xl font-bold text-white mb-2">{gridData.title}</h2>
-			<p class="text-slate-400">{gridData.subtitle}</p>
+			<h2 class="text-3xl font-bold text-gray-900 mb-2">{gridData.title}</h2>
+			<p class="text-gray-600">{gridData.subtitle}</p>
 		</div>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 			{#each gridData.platforms as platform, i}
@@ -265,16 +266,16 @@
 					use:scrollReveal={{ delay: i * 80 }}
 				>
 					<div class="mb-4">
-						<h3 class="text-lg font-bold text-white">{platform.name}</h3>
-						<p class="text-sm text-slate-400 mt-1">{platform.tagline}</p>
+						<h3 class="text-lg font-bold text-gray-900">{platform.name}</h3>
+						<p class="text-sm text-gray-500 mt-1">{platform.tagline}</p>
 					</div>
 					<div class="mb-4">
 						<span class="text-xl font-bold {c(platform.color).text}">{platform.pricing}</span>
 					</div>
 					<ul class="space-y-2 mb-6 flex-1">
 						{#each platform.features as feature}
-							<li class="flex items-start gap-2 text-sm text-slate-300">
-								<svg class="w-4 h-4 text-emerald-400 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<li class="flex items-start gap-2 text-sm text-gray-700">
+								<svg class="w-4 h-4 text-emerald-600 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 								</svg>
 								{feature}
@@ -283,7 +284,7 @@
 					</ul>
 					<a
 						href={platform.cta_href}
-						class="block text-center glass text-white hover:bg-slate-800/80 transition-all rounded-xl px-6 py-3 font-semibold text-sm"
+						class="block text-center bg-black text-white hover:bg-gray-800 transition-all rounded-xl px-6 py-3 font-semibold text-sm"
 						data-camino-cta="platform-{platform.id}"
 					>
 						{$_('plataformas.trialButton')}
@@ -297,19 +298,19 @@
 <!-- Patadas Discovery CTA -->
 <section class="py-16 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-3xl mx-auto text-center" use:scrollReveal>
-		<div class="glass rounded-2xl p-8 md:p-12 border border-orange-500/20">
+		<div class="glass rounded-2xl p-8 md:p-12">
 			<div class="text-4xl mb-4">⚡</div>
-			<h2 class="text-2xl md:text-3xl font-bold text-white mb-3">
+			<h2 class="text-2xl md:text-3xl font-bold text-gray-900 mb-3">
 				{isEs ? '¿No sabes cuál necesitas?' : "Not sure which one you need?"}
 			</h2>
-			<p class="text-lg text-slate-400 mb-6 max-w-xl mx-auto">
+			<p class="text-lg text-gray-600 mb-6 max-w-xl mx-auto">
 				{isEs
 					? 'Nuestro marketplace de IA analiza tu negocio en 2 minutos y te recomienda la combinación perfecta — o te conecta con un desarrollador certificado.'
 					: 'Our AI marketplace analyzes your business in 2 minutes and recommends the perfect product combination — or connects you with a vetted developer.'}
 			</p>
 			<a
 				href="https://patadas.redbroomsoftware.com/get-started"
-				class="inline-block bg-gradient-to-r from-orange-500 to-orange-600 text-white hover:from-orange-600 hover:to-orange-700 transition-all rounded-xl px-8 py-4 font-semibold shadow-lg shadow-orange-500/25 hover:shadow-orange-500/40"
+				class="inline-block bg-black text-white hover:bg-gray-800 transition-all rounded-xl px-8 py-4 font-semibold"
 				data-camino-cta="patadas-discovery"
 			>
 				{isEs ? 'Obtener recomendación gratis →' : 'Get free recommendation →'}
@@ -321,15 +322,15 @@
 <!-- Enterprise CTA -->
 <section class="py-20 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-4xl mx-auto text-center" use:scrollReveal>
-		<h2 class="text-3xl md:text-4xl font-bold text-white mb-4">
+		<h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
 			{ctaData.title}
 		</h2>
-		<p class="text-lg text-slate-400 mb-8 max-w-2xl mx-auto">{ctaData.subtitle}</p>
+		<p class="text-lg text-gray-600 mb-8 max-w-2xl mx-auto">{ctaData.subtitle}</p>
 		<div class="flex flex-col sm:flex-row gap-4 justify-center">
-			<a href={ctaData.cta_primary.href} class="bg-gradient-to-r from-blue-500 to-purple-600 text-white hover:from-blue-600 hover:to-purple-700 transition-all rounded-xl px-8 py-4 font-semibold shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40" data-camino-cta="enterprise-primary">
+			<a href={ctaData.cta_primary.href} class="bg-black text-white hover:bg-gray-800 transition-all rounded-xl px-8 py-4 font-semibold" data-camino-cta="enterprise-primary">
 				{ctaData.cta_primary.text}
 			</a>
-			<a href={ctaData.cta_secondary.href} class="glass text-white hover:bg-slate-800/80 transition-all rounded-xl px-8 py-4 font-semibold" data-camino-cta="enterprise-secondary">
+			<a href={ctaData.cta_secondary.href} class="bg-white text-gray-900 border border-gray-300 hover:border-gray-900 transition-all rounded-xl px-8 py-4 font-semibold" data-camino-cta="enterprise-secondary">
 				{ctaData.cta_secondary.text}
 			</a>
 		</div>

--- a/src/routes/portafolio/+page.svelte
+++ b/src/routes/portafolio/+page.svelte
@@ -64,16 +64,15 @@
 
 <!-- Hero -->
 <section class="py-20 px-4 sm:px-6 lg:px-8 relative">
-	<div class="absolute inset-0 bg-gradient-to-b from-purple-600/10 via-transparent to-transparent"></div>
 	<div class="max-w-7xl mx-auto text-center relative">
-		<div class="inline-flex items-center px-4 py-2 glass rounded-full text-sm text-slate-300 mb-6">
-			<span class="w-2 h-2 bg-emerald-400 rounded-full mr-2 animate-pulse"></span>
+		<div class="inline-flex items-center px-4 py-2 glass rounded-full text-sm text-gray-600 mb-6">
+			<span class="w-2 h-2 bg-emerald-500 rounded-full mr-2 animate-pulse"></span>
 			{$_("portfolio.hero.badge")}
 		</div>
-		<h2 class="text-4xl md:text-6xl font-bold text-white mb-6">
-			{$_("portfolio.hero.titlePart1")} <span class="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-400">{$_("portfolio.hero.titleHighlight")}</span>
+		<h2 class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 tracking-tight">
+			{$_("portfolio.hero.titlePart1")} <span class="text-gray-500">{$_("portfolio.hero.titleHighlight")}</span>
 		</h2>
-		<p class="text-xl text-slate-400 max-w-3xl mx-auto">
+		<p class="text-xl text-gray-600 max-w-3xl mx-auto">
 			{$_("portfolio.hero.subtitle")}
 		</p>
 	</div>
@@ -88,8 +87,8 @@
 					onclick={() => activeCategory = cat.value}
 					class="px-4 py-2 rounded-full text-sm font-medium transition-all
 						{activeCategory === cat.value
-							? 'bg-purple-500/20 text-purple-300 border border-purple-500/30'
-							: 'glass text-slate-400 hover:text-white'}"
+							? 'bg-black text-white border border-black'
+							: 'glass text-gray-600 hover:text-gray-900'}"
 				>
 					{$_(cat.labelKey)}
 				</button>
@@ -105,42 +104,42 @@
 			{#each filteredProducts as product, i (product.key)}
 				<article
 					use:scrollReveal={{ delay: Math.min(i * 80, 400) }}
-					class="glass rounded-2xl p-6 hover:border-purple-500/50 transition-all hover:shadow-lg hover:shadow-purple-500/10 group"
+					class="glass rounded-2xl p-6 hover:border-gray-900 transition-all hover:shadow-md group"
 				>
 					<div class="flex items-start justify-between mb-4">
 						<div class="flex items-center gap-4">
-							<div class="w-14 h-14 bg-slate-800/80 rounded-xl flex items-center justify-center text-3xl group-hover:scale-110 transition-transform">
+							<div class="w-14 h-14 bg-gray-100 rounded-xl flex items-center justify-center text-3xl group-hover:scale-110 transition-transform">
 								{product.icon}
 							</div>
 							<div>
-								<h3 class="text-xl font-bold text-white">{$_(`portfolio.products.${product.key}.name`)}</h3>
-								<p class="text-sm text-purple-400">{$_(`portfolio.products.${product.key}.subtitle`)}</p>
+								<h3 class="text-xl font-bold text-gray-900">{$_(`portfolio.products.${product.key}.name`)}</h3>
+								<p class="text-sm text-gray-500">{$_(`portfolio.products.${product.key}.subtitle`)}</p>
 							</div>
 						</div>
 						<div class="flex flex-col items-end gap-1">
-							<span class="px-3 py-1 bg-emerald-500/20 text-emerald-400 rounded-full text-xs font-medium">
+							<span class="px-3 py-1 bg-emerald-50 text-emerald-700 rounded-full text-xs font-medium">
 								{$_('portfolio.products.live')}
 							</span>
 							{#if product.agentBadgeKey}
-								<span class="px-3 py-1 bg-purple-500/20 text-purple-400 rounded-full text-xs font-medium">
+								<span class="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-medium">
 									{$_(product.agentBadgeKey)}
 								</span>
 							{/if}
 						</div>
 					</div>
 
-					<p class="text-slate-400 text-sm mb-4">{$_(`portfolio.products.${product.key}.description`)}</p>
+					<p class="text-gray-600 text-sm mb-4">{$_(`portfolio.products.${product.key}.description`)}</p>
 
 					<div class="flex flex-wrap gap-2 mb-4">
 						{#each product.tech as tech}
-							<span class="px-2 py-1 bg-slate-800/80 text-slate-300 rounded text-xs">{tech}</span>
+							<span class="px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs">{tech}</span>
 						{/each}
 					</div>
 
 					<ul class="grid grid-cols-2 gap-2 mb-4">
 						{#each highlightIndices as idx}
-							<li class="flex items-center text-sm text-slate-300">
-								<svg class="w-4 h-4 text-purple-400 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<li class="flex items-center text-sm text-gray-700">
+								<svg class="w-4 h-4 text-emerald-600 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
 								</svg>
 								{$_(`portfolio.products.${product.key}.highlights.${idx}`)}
@@ -148,7 +147,7 @@
 						{/each}
 					</ul>
 
-					<a href={product.url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-purple-400 hover:text-purple-300 text-sm font-medium transition-colors">
+					<a href={product.url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-900 hover:text-gray-600 text-sm font-medium transition-colors">
 						{$_('portfolio.products.visitProduct')}
 						<svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
@@ -161,16 +160,16 @@
 </section>
 
 <!-- B2C Services -->
-<section class="py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-slate-950 via-emerald-950/20 to-slate-950">
+<section class="py-20 px-4 sm:px-6 lg:px-8 bg-gray-50">
 	<div class="max-w-7xl mx-auto">
 		<div class="text-center mb-12" use:scrollReveal>
-			<div class="inline-flex items-center px-4 py-2 bg-emerald-500/20 border border-emerald-500/30 rounded-full text-sm text-emerald-300 mb-6">
+			<div class="inline-flex items-center px-4 py-2 bg-emerald-50 border border-emerald-200 rounded-full text-sm text-emerald-700 mb-6">
 				{$_("portfolio.b2cServices.new")}
 			</div>
-			<h2 class="text-3xl md:text-4xl font-bold text-white mb-4">
-				{$_("portfolio.b2cServices.title").split(" ")[0]} <span class="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-teal-400">B2C</span>
+			<h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+				{$_("portfolio.b2cServices.title").split(" ")[0]} <span class="text-gray-500">B2C</span>
 			</h2>
-			<p class="text-xl text-slate-400 max-w-2xl mx-auto">
+			<p class="text-xl text-gray-600 max-w-2xl mx-auto">
 				{$_("portfolio.b2cServices.subtitle")}
 			</p>
 		</div>
@@ -179,35 +178,35 @@
 			{#each b2cServiceKeys as service, i}
 				<article
 					use:scrollReveal={{ delay: i * 100 }}
-					class="glass rounded-2xl p-6 hover:border-emerald-500/50 transition-all hover:shadow-lg hover:shadow-emerald-500/10 group"
+					class="glass rounded-2xl p-6 hover:border-gray-900 transition-all hover:shadow-md group"
 				>
 					<div class="flex items-start justify-between mb-4">
 						<div class="flex items-center gap-4">
-							<div class="w-14 h-14 bg-emerald-500/10 rounded-xl flex items-center justify-center text-3xl group-hover:scale-110 transition-transform">
+							<div class="w-14 h-14 bg-emerald-50 rounded-xl flex items-center justify-center text-3xl group-hover:scale-110 transition-transform">
 								{service.icon}
 							</div>
 							<div>
-								<h3 class="text-xl font-bold text-white">{$_(`portfolio.b2cServices.${service.key}.name`)}</h3>
-								<p class="text-sm text-emerald-400">{$_(`portfolio.b2cServices.${service.key}.subtitle`)}</p>
+								<h3 class="text-xl font-bold text-gray-900">{$_(`portfolio.b2cServices.${service.key}.name`)}</h3>
+								<p class="text-sm text-gray-500">{$_(`portfolio.b2cServices.${service.key}.subtitle`)}</p>
 							</div>
 						</div>
 						{#if service.status === 'live'}
-							<span class="px-3 py-1 bg-emerald-500/20 text-emerald-400 rounded-full text-xs font-medium">
+							<span class="px-3 py-1 bg-emerald-50 text-emerald-700 rounded-full text-xs font-medium">
 								{$_('portfolio.b2cServices.active')}
 							</span>
 						{:else}
-							<span class="px-3 py-1 bg-amber-500/20 text-amber-400 rounded-full text-xs font-medium">
+							<span class="px-3 py-1 bg-amber-50 text-amber-700 rounded-full text-xs font-medium">
 								{$_('portfolio.b2cServices.comingSoon')}
 							</span>
 						{/if}
 					</div>
 
-					<p class="text-slate-400 text-sm mb-4">{$_(`portfolio.b2cServices.${service.key}.description`)}</p>
+					<p class="text-gray-600 text-sm mb-4">{$_(`portfolio.b2cServices.${service.key}.description`)}</p>
 
 					<ul class="grid grid-cols-2 gap-2 mb-4">
 						{#each highlightIndices as idx}
-							<li class="flex items-center text-sm text-slate-300">
-								<svg class="w-4 h-4 text-emerald-400 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<li class="flex items-center text-sm text-gray-700">
+								<svg class="w-4 h-4 text-emerald-600 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
 								</svg>
 								{$_(`portfolio.b2cServices.${service.key}.highlights.${idx}`)}
@@ -216,14 +215,14 @@
 					</ul>
 
 					{#if service.status === 'live'}
-						<a href={service.url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-emerald-400 hover:text-emerald-300 text-sm font-medium transition-colors">
+						<a href={service.url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-900 hover:text-gray-600 text-sm font-medium transition-colors">
 							{$_('portfolio.b2cServices.learnMore')}
 							<svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
 							</svg>
 						</a>
 					{:else}
-						<span class="inline-flex items-center text-slate-500 text-sm">{$_("portfolio.b2cServices.availableSoon")}</span>
+						<span class="inline-flex items-center text-gray-400 text-sm">{$_("portfolio.b2cServices.availableSoon")}</span>
 					{/if}
 				</article>
 			{/each}
@@ -232,28 +231,28 @@
 </section>
 
 <!-- Stats -->
-<section class="py-16 px-4 sm:px-6 lg:px-8 bg-slate-900/50">
+<section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
 	<div class="max-w-7xl mx-auto">
 		<div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-center" use:scrollReveal>
 			<div>
-				<p class="text-4xl font-bold text-white"><AnimatedCounter value={16} /></p>
-				<p class="text-slate-400">{$_("portfolio.stats.saasProducts")}</p>
+				<p class="text-4xl font-bold text-gray-900"><AnimatedCounter value={16} /></p>
+				<p class="text-gray-500">{$_("portfolio.stats.saasProducts")}</p>
 			</div>
 			<div>
-				<p class="text-4xl font-bold text-white"><AnimatedCounter value={5} /></p>
-				<p class="text-slate-400">{$_("portfolio.stats.b2cServices")}</p>
+				<p class="text-4xl font-bold text-gray-900"><AnimatedCounter value={5} /></p>
+				<p class="text-gray-500">{$_("portfolio.stats.b2cServices")}</p>
 			</div>
 			<div>
-				<p class="text-4xl font-bold text-white"><AnimatedCounter value={10} suffix="+" /></p>
-				<p class="text-slate-400">{$_("portfolio.stats.industries")}</p>
+				<p class="text-4xl font-bold text-gray-900"><AnimatedCounter value={10} suffix="+" /></p>
+				<p class="text-gray-500">{$_("portfolio.stats.industries")}</p>
 			</div>
 			<div>
-				<p class="text-4xl font-bold text-white">99.9%</p>
-				<p class="text-slate-400">{$_("portfolio.stats.uptime")}</p>
+				<p class="text-4xl font-bold text-gray-900">99.9%</p>
+				<p class="text-gray-500">{$_("portfolio.stats.uptime")}</p>
 			</div>
 			<div>
-				<p class="text-4xl font-bold text-white">24/7</p>
-				<p class="text-slate-400">{$_("portfolio.stats.support")}</p>
+				<p class="text-4xl font-bold text-gray-900">24/7</p>
+				<p class="text-gray-500">{$_("portfolio.stats.support")}</p>
 			</div>
 		</div>
 	</div>
@@ -262,9 +261,9 @@
 <!-- CTA -->
 <section class="py-20 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-3xl mx-auto text-center" use:scrollReveal>
-		<h3 class="text-3xl font-bold text-white mb-4">{$_("portfolio.cta.title")}</h3>
-		<p class="text-slate-400 mb-8">{$_("portfolio.cta.subtitle")}</p>
-		<a href="/contacto" class="inline-flex px-8 py-4 bg-gradient-to-r from-purple-500 to-pink-600 text-white rounded-xl hover:from-purple-600 hover:to-pink-700 transition-all font-semibold hover:shadow-lg hover:shadow-purple-500/25 hover:-translate-y-0.5">
+		<h3 class="text-3xl font-bold text-gray-900 mb-4">{$_("portfolio.cta.title")}</h3>
+		<p class="text-gray-600 mb-8">{$_("portfolio.cta.subtitle")}</p>
+		<a href="/contacto" class="inline-flex px-8 py-4 bg-black text-white rounded-xl hover:bg-gray-800 transition-all font-semibold hover:-translate-y-0.5">
 			{$_('portfolio.cta.button')}
 		</a>
 	</div>

--- a/src/routes/privacidad/+page.svelte
+++ b/src/routes/privacidad/+page.svelte
@@ -23,121 +23,121 @@
 <main class="py-16 px-4 sm:px-6 lg:px-8">
 	<article class="max-w-4xl mx-auto" use:scrollReveal>
 		<div class="mb-12">
-			<h1 class="text-4xl font-bold text-white mb-4">{$_('privacy.title')}</h1>
-			<p class="text-slate-400">{$_('privacy.lastUpdated')}: {$_('privacy.date')}</p>
+			<h1 class="text-4xl font-bold text-gray-900 mb-4 tracking-tight">{$_('privacy.title')}</h1>
+			<p class="text-gray-500">{$_('privacy.lastUpdated')}: {$_('privacy.date')}</p>
 		</div>
 
-		<div class="prose prose-invert prose-slate max-w-none space-y-8">
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section1.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
-					<strong class="text-white">Red Broom Software S.A.S. de C.V.</strong> {$_('privacy.section1.p1')}
+		<div class="prose prose-slate max-w-none space-y-8">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section1.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
+					<strong class="text-gray-900">Red Broom Software S.A.S. de C.V.</strong> {$_('privacy.section1.p1')}
 				</p>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('privacy.section1.p2')}
-					<a href="mailto:dia@redbroomsoftware.com" class="text-blue-400 hover:text-blue-300">dia@redbroomsoftware.com</a>
+					<a href="mailto:dia@redbroomsoftware.com" class="text-gray-900 underline hover:text-gray-600">dia@redbroomsoftware.com</a>
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section2.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section2.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('privacy.section2.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each dataItems as item}
-						<li><strong class="text-white">{$_(`privacy.section2.items.${item}.label`)}</strong> {$_(`privacy.section2.items.${item}.desc`)}</li>
+						<li><strong class="text-gray-900">{$_(`privacy.section2.items.${item}.label`)}</strong> {$_(`privacy.section2.items.${item}.desc`)}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section3.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section3.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('privacy.section3.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each primaryPurposes as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
-				<p class="text-slate-300 leading-relaxed mt-4 mb-4">
+				<p class="text-gray-700 leading-relaxed mt-4 mb-4">
 					{$_('privacy.section3.secondaryIntro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each secondaryPurposes as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section4.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section4.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('privacy.section4.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each transferItems as item}
-						<li><strong class="text-white">{$_(`privacy.section4.items.${item}.label`)}</strong> {$_(`privacy.section4.items.${item}.desc`)}</li>
+						<li><strong class="text-gray-900">{$_(`privacy.section4.items.${item}.label`)}</strong> {$_(`privacy.section4.items.${item}.desc`)}</li>
 					{/each}
 				</ul>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('privacy.section4.note')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section5.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section5.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('privacy.section5.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each arcoItems as item}
-						<li><strong class="text-white">{$_(`privacy.section5.${item}.label`)}</strong> {$_(`privacy.section5.${item}.desc`)}</li>
+						<li><strong class="text-gray-900">{$_(`privacy.section5.${item}.label`)}</strong> {$_(`privacy.section5.${item}.desc`)}</li>
 					{/each}
 				</ul>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('privacy.section5.howTo')}
-					<a href="mailto:dia@redbroomsoftware.com" class="text-blue-400 hover:text-blue-300">dia@redbroomsoftware.com</a>
+					<a href="mailto:dia@redbroomsoftware.com" class="text-gray-900 underline hover:text-gray-600">dia@redbroomsoftware.com</a>
 					{$_('privacy.section5.howToSuffix')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section6.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section6.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('privacy.section6.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2 mt-4">
+				<ul class="list-disc list-inside text-gray-700 space-y-2 mt-4">
 					{#each securityItems as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section7.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section7.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('privacy.section7.content')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section8.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section8.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('privacy.section8.content')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('privacy.section9.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('privacy.section9.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('privacy.section9.intro')}
 				</p>
-				<div class="mt-4 text-slate-300">
-					<p><strong class="text-white">Red Broom Software S.A.S. de C.V.</strong></p>
+				<div class="mt-4 text-gray-700">
+					<p><strong class="text-gray-900">Red Broom Software S.A.S. de C.V.</strong></p>
 					<p>{$_('privacy.section9.location')}</p>
-					<p>Email: <a href="mailto:dia@redbroomsoftware.com" class="text-blue-400 hover:text-blue-300">dia@redbroomsoftware.com</a></p>
+					<p>Email: <a href="mailto:dia@redbroomsoftware.com" class="text-gray-900 underline hover:text-gray-600">dia@redbroomsoftware.com</a></p>
 				</div>
 			</section>
 		</div>

--- a/src/routes/servicios/+page.svelte
+++ b/src/routes/servicios/+page.svelte
@@ -31,12 +31,11 @@
 
 <!-- Hero -->
 <section class="py-20 px-4 sm:px-6 lg:px-8 relative">
-	<div class="absolute inset-0 bg-gradient-to-b from-blue-600/10 via-transparent to-transparent"></div>
 	<div class="max-w-7xl mx-auto text-center relative">
-		<h2 class="text-4xl md:text-6xl font-bold text-white mb-6">
-			{$_('services.hero.titlePart1')} <span class="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">{$_('services.hero.titleHighlight')}</span> {$_('services.hero.titlePart2')}
+		<h2 class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 tracking-tight">
+			{$_('services.hero.titlePart1')} <span class="text-gray-500">{$_('services.hero.titleHighlight')}</span> {$_('services.hero.titlePart2')}
 		</h2>
-		<p class="text-xl text-slate-400 max-w-3xl mx-auto">
+		<p class="text-xl text-gray-600 max-w-3xl mx-auto">
 			{$_('services.hero.subtitle')}
 		</p>
 	</div>
@@ -47,17 +46,17 @@
 	<div class="max-w-7xl mx-auto">
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 			{#each services as service, i}
-				<article use:scrollReveal={{ delay: i * 100 }} class="glass rounded-2xl p-6 hover:border-blue-500/50 transition-all hover:shadow-lg hover:shadow-blue-500/10">
-					<div class="w-14 h-14 bg-slate-800/80 rounded-xl flex items-center justify-center text-3xl mb-4">
+				<article use:scrollReveal={{ delay: i * 100 }} class="glass rounded-2xl p-6 hover:border-gray-900 transition-all hover:shadow-md">
+					<div class="w-14 h-14 bg-gray-100 rounded-xl flex items-center justify-center text-3xl mb-4">
 						{service.icon}
 					</div>
-					<h3 class="text-xl font-bold text-white mb-1">{service.title}</h3>
-					<p class="text-sm text-blue-400 mb-3">{service.subtitle}</p>
-					<p class="text-slate-400 text-sm mb-4">{service.description}</p>
+					<h3 class="text-xl font-bold text-gray-900 mb-1">{service.title}</h3>
+					<p class="text-sm text-gray-500 mb-3">{service.subtitle}</p>
+					<p class="text-gray-600 text-sm mb-4">{service.description}</p>
 					<ul class="space-y-2">
 						{#each service.features as feature}
-							<li class="flex items-center text-sm text-slate-300">
-								<svg class="w-4 h-4 text-emerald-400 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<li class="flex items-center text-sm text-gray-700">
+								<svg class="w-4 h-4 text-emerald-600 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
 								</svg>
 								{feature}
@@ -71,12 +70,12 @@
 </section>
 
 <!-- Process Section -->
-<section class="py-16 px-4 sm:px-6 lg:px-8 bg-slate-900/50">
+<section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
 	<div class="max-w-7xl mx-auto">
-		<h3 class="text-3xl font-bold text-white text-center mb-12" use:scrollReveal>{$_('services.process.title')}</h3>
+		<h3 class="text-3xl font-bold text-gray-900 text-center mb-12" use:scrollReveal>{$_('services.process.title')}</h3>
 		<div class="grid grid-cols-1 md:grid-cols-4 gap-6 relative">
 			<!-- Connecting line (desktop) -->
-			<div class="hidden md:block absolute top-6 left-[12.5%] right-[12.5%] h-0.5 bg-gradient-to-r from-blue-500/50 via-purple-500/50 to-blue-500/50"></div>
+			<div class="hidden md:block absolute top-6 left-[12.5%] right-[12.5%] h-0.5 bg-gray-200"></div>
 			{#each [
 				{ num: 1, title: $_('services.process.step1.title'), desc: $_('services.process.step1.desc') },
 				{ num: 2, title: $_('services.process.step2.title'), desc: $_('services.process.step2.desc') },
@@ -84,11 +83,11 @@
 				{ num: 4, title: $_('services.process.step4.title'), desc: $_('services.process.step4.desc') }
 			] as step, i}
 				<div class="text-center relative" use:scrollReveal={{ delay: i * 150 }}>
-					<div class="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold mx-auto mb-4 relative z-10 shadow-lg shadow-blue-500/25">
+					<div class="w-12 h-12 bg-black rounded-full flex items-center justify-center text-white font-bold mx-auto mb-4 relative z-10">
 						{step.num}
 					</div>
-					<h4 class="text-white font-semibold mb-2">{step.title}</h4>
-					<p class="text-slate-400 text-sm">{step.desc}</p>
+					<h4 class="text-gray-900 font-semibold mb-2">{step.title}</h4>
+					<p class="text-gray-600 text-sm">{step.desc}</p>
 				</div>
 			{/each}
 		</div>
@@ -98,9 +97,9 @@
 <!-- CTA -->
 <section class="py-20 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-3xl mx-auto text-center">
-		<h3 class="text-3xl font-bold text-white mb-4">{$_('services.cta.title')}</h3>
-		<p class="text-slate-400 mb-8">{$_('services.cta.subtitle')}</p>
-		<a href="/contacto" class="inline-flex px-8 py-4 bg-gradient-to-r from-blue-500 to-purple-600 text-white rounded-xl hover:from-blue-600 hover:to-purple-700 transition-all font-semibold">
+		<h3 class="text-3xl font-bold text-gray-900 mb-4">{$_('services.cta.title')}</h3>
+		<p class="text-gray-600 mb-8">{$_('services.cta.subtitle')}</p>
+		<a href="/contacto" class="inline-flex px-8 py-4 bg-black text-white rounded-xl hover:bg-gray-800 transition-all font-semibold">
 			{$_('services.cta.button')}
 		</a>
 	</div>

--- a/src/routes/tecnologia/+page.svelte
+++ b/src/routes/tecnologia/+page.svelte
@@ -58,12 +58,11 @@
 
 <!-- Hero -->
 <section class="py-20 px-4 sm:px-6 lg:px-8 relative">
-	<div class="absolute inset-0 bg-gradient-to-b from-emerald-600/10 via-transparent to-transparent"></div>
 	<div class="max-w-7xl mx-auto text-center relative">
-		<h2 class="text-4xl md:text-6xl font-bold text-white mb-6">
-			{$_('technology.hero.titlePart1')} <span class="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-cyan-400">{$_('technology.hero.titleHighlight')}</span>
+		<h2 class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 tracking-tight">
+			{$_('technology.hero.titlePart1')} <span class="text-gray-500">{$_('technology.hero.titleHighlight')}</span>
 		</h2>
-		<p class="text-xl text-slate-400 max-w-3xl mx-auto">
+		<p class="text-xl text-gray-600 max-w-3xl mx-auto">
 			{$_('technology.hero.subtitle')}
 		</p>
 	</div>
@@ -75,8 +74,8 @@
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
 			{#each principleKeys as key, i}
 				<div use:scrollReveal={{ delay: i * 100 }} class="glass rounded-xl p-6">
-					<h3 class="text-lg font-bold text-emerald-400 mb-2">{$_(`technology.principles.${key}.title`)}</h3>
-					<p class="text-slate-400 text-sm">{$_(`technology.principles.${key}.description`)}</p>
+					<h3 class="text-lg font-bold text-gray-900 mb-2">{$_(`technology.principles.${key}.title`)}</h3>
+					<p class="text-gray-600 text-sm">{$_(`technology.principles.${key}.description`)}</p>
 				</div>
 			{/each}
 		</div>
@@ -86,13 +85,13 @@
 <!-- Frontend -->
 <section class="py-12 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-7xl mx-auto">
-		<h3 class="text-2xl font-bold text-white mb-6">{$_("technology.sections.frontend")}</h3>
+		<h3 class="text-2xl font-bold text-gray-900 mb-6">{$_("technology.sections.frontend")}</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 			{#each techStackKeys.frontend as tech}
-				<div class="glass rounded-xl p-5 hover:border-emerald-500/50 transition-all">
+				<div class="glass rounded-xl p-5 hover:border-gray-900 transition-all">
 					<div class="text-2xl mb-2">{tech.icon}</div>
-					<h4 class="text-white font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
-					<p class="text-slate-400 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
+					<h4 class="text-gray-900 font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
+					<p class="text-gray-600 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
 				</div>
 			{/each}
 		</div>
@@ -102,13 +101,13 @@
 <!-- Backend -->
 <section class="py-12 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-7xl mx-auto">
-		<h3 class="text-2xl font-bold text-white mb-6">{$_("technology.sections.backend")}</h3>
+		<h3 class="text-2xl font-bold text-gray-900 mb-6">{$_("technology.sections.backend")}</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 			{#each techStackKeys.backend as tech}
-				<div class="glass rounded-xl p-5 hover:border-emerald-500/50 transition-all">
+				<div class="glass rounded-xl p-5 hover:border-gray-900 transition-all">
 					<div class="text-2xl mb-2">{tech.icon}</div>
-					<h4 class="text-white font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
-					<p class="text-slate-400 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
+					<h4 class="text-gray-900 font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
+					<p class="text-gray-600 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
 				</div>
 			{/each}
 		</div>
@@ -116,15 +115,15 @@
 </section>
 
 <!-- AI -->
-<section class="py-12 px-4 sm:px-6 lg:px-8 bg-slate-900/50">
+<section class="py-12 px-4 sm:px-6 lg:px-8 bg-gray-50">
 	<div class="max-w-7xl mx-auto">
-		<h3 class="text-2xl font-bold text-white mb-6">{$_("technology.sections.ai")}</h3>
+		<h3 class="text-2xl font-bold text-gray-900 mb-6">{$_("technology.sections.ai")}</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 			{#each techStackKeys.ai as tech}
-				<div class="glass rounded-xl p-5 hover:border-purple-500/50 transition-all">
+				<div class="glass rounded-xl p-5 hover:border-gray-900 transition-all">
 					<div class="text-2xl mb-2">{tech.icon}</div>
-					<h4 class="text-white font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
-					<p class="text-slate-400 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
+					<h4 class="text-gray-900 font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
+					<p class="text-gray-600 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
 				</div>
 			{/each}
 		</div>
@@ -135,8 +134,8 @@
 <section class="py-16 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-7xl mx-auto">
 		<div class="mb-10" use:scrollReveal>
-			<h3 class="text-2xl font-bold text-white mb-2">{$_('technology.agents.title')}</h3>
-			<p class="text-slate-400 max-w-2xl">
+			<h3 class="text-2xl font-bold text-gray-900 mb-2">{$_('technology.agents.title')}</h3>
+			<p class="text-gray-600 max-w-2xl">
 				{$_('technology.agents.subtitle')}
 			</p>
 		</div>
@@ -144,77 +143,77 @@
 		<!-- Pipeline flow -->
 		<div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-12">
 			<div class="glass rounded-xl p-5">
-				<div class="text-purple-400 font-mono text-xs mb-2">1. REQUEST</div>
-				<p class="text-white font-semibold text-sm mb-1">{$_('technology.agents.pipeline.request.title')}</p>
-				<p class="text-slate-400 text-xs">{$_('technology.agents.pipeline.request.desc')}</p>
+				<div class="text-gray-900 font-mono text-xs mb-2">1. REQUEST</div>
+				<p class="text-gray-900 font-semibold text-sm mb-1">{$_('technology.agents.pipeline.request.title')}</p>
+				<p class="text-gray-600 text-xs">{$_('technology.agents.pipeline.request.desc')}</p>
 			</div>
-			<div class="bg-slate-900 border border-purple-500/30 rounded-xl p-5">
-				<div class="text-purple-400 font-mono text-xs mb-2">2. ROUTE</div>
-				<p class="text-white font-semibold text-sm mb-1">{$_('technology.agents.pipeline.route.title')}</p>
-				<p class="text-slate-400 text-xs">{$_('technology.agents.pipeline.route.desc')}</p>
-			</div>
-			<div class="glass rounded-xl p-5">
-				<div class="text-purple-400 font-mono text-xs mb-2">3. EXECUTE</div>
-				<p class="text-white font-semibold text-sm mb-1">{$_('technology.agents.pipeline.execute.title')}</p>
-				<p class="text-slate-400 text-xs">{$_('technology.agents.pipeline.execute.desc')}</p>
+			<div class="bg-gray-50 border border-gray-900 rounded-xl p-5">
+				<div class="text-gray-900 font-mono text-xs mb-2">2. ROUTE</div>
+				<p class="text-gray-900 font-semibold text-sm mb-1">{$_('technology.agents.pipeline.route.title')}</p>
+				<p class="text-gray-600 text-xs">{$_('technology.agents.pipeline.route.desc')}</p>
 			</div>
 			<div class="glass rounded-xl p-5">
-				<div class="text-purple-400 font-mono text-xs mb-2">4. METER</div>
-				<p class="text-white font-semibold text-sm mb-1">{$_('technology.agents.pipeline.meter.title')}</p>
-				<p class="text-slate-400 text-xs">{$_('technology.agents.pipeline.meter.desc')}</p>
+				<div class="text-gray-900 font-mono text-xs mb-2">3. EXECUTE</div>
+				<p class="text-gray-900 font-semibold text-sm mb-1">{$_('technology.agents.pipeline.execute.title')}</p>
+				<p class="text-gray-600 text-xs">{$_('technology.agents.pipeline.execute.desc')}</p>
+			</div>
+			<div class="glass rounded-xl p-5">
+				<div class="text-gray-900 font-mono text-xs mb-2">4. METER</div>
+				<p class="text-gray-900 font-semibold text-sm mb-1">{$_('technology.agents.pipeline.meter.title')}</p>
+				<p class="text-gray-600 text-xs">{$_('technology.agents.pipeline.meter.desc')}</p>
 			</div>
 		</div>
 
 		<!-- Live agents -->
-		<h4 class="text-lg font-semibold text-white mb-4" use:scrollReveal>{$_('technology.agents.liveTitle')}</h4>
+		<h4 class="text-lg font-semibold text-gray-900 mb-4" use:scrollReveal>{$_('technology.agents.liveTitle')}</h4>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 			<div class="glass rounded-xl p-5">
 				<div class="flex items-center gap-2 mb-3">
-					<span class="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></span>
-					<span class="text-xs text-emerald-400 font-medium">{$_('technology.agents.live')} · Colectiva</span>
+					<span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+					<span class="text-xs text-emerald-600 font-medium">{$_('technology.agents.live')} · Colectiva</span>
 				</div>
-				<h5 class="text-white font-semibold mb-1">{$_('technology.agents.oracle.title')}</h5>
-				<p class="text-slate-400 text-sm">{$_('technology.agents.oracle.desc')}</p>
+				<h5 class="text-gray-900 font-semibold mb-1">{$_('technology.agents.oracle.title')}</h5>
+				<p class="text-gray-600 text-sm">{$_('technology.agents.oracle.desc')}</p>
 			</div>
 			<div class="glass rounded-xl p-5">
 				<div class="flex items-center gap-2 mb-3">
-					<span class="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></span>
-					<span class="text-xs text-emerald-400 font-medium">{$_('technology.agents.live')} · Rito</span>
+					<span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+					<span class="text-xs text-emerald-600 font-medium">{$_('technology.agents.live')} · Rito</span>
 				</div>
-				<h5 class="text-white font-semibold mb-1">{$_('technology.agents.dealCopilot.title')}</h5>
-				<p class="text-slate-400 text-sm">{$_('technology.agents.dealCopilot.desc')}</p>
+				<h5 class="text-gray-900 font-semibold mb-1">{$_('technology.agents.dealCopilot.title')}</h5>
+				<p class="text-gray-600 text-sm">{$_('technology.agents.dealCopilot.desc')}</p>
 			</div>
 			<div class="glass rounded-xl p-5">
 				<div class="flex items-center gap-2 mb-3">
-					<span class="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></span>
-					<span class="text-xs text-emerald-400 font-medium">{$_('technology.agents.live')} · Camino</span>
+					<span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+					<span class="text-xs text-emerald-600 font-medium">{$_('technology.agents.live')} · Camino</span>
 				</div>
-				<h5 class="text-white font-semibold mb-1">{$_('technology.agents.support.title')}</h5>
-				<p class="text-slate-400 text-sm">{$_('technology.agents.support.desc')}</p>
+				<h5 class="text-gray-900 font-semibold mb-1">{$_('technology.agents.support.title')}</h5>
+				<p class="text-gray-600 text-sm">{$_('technology.agents.support.desc')}</p>
 			</div>
 			<div class="glass rounded-xl p-5">
 				<div class="flex items-center gap-2 mb-3">
-					<span class="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></span>
-					<span class="text-xs text-emerald-400 font-medium">{$_('technology.agents.live')} · Plenura</span>
+					<span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+					<span class="text-xs text-emerald-600 font-medium">{$_('technology.agents.live')} · Plenura</span>
 				</div>
-				<h5 class="text-white font-semibold mb-1">{$_('technology.agents.wellness.title')}</h5>
-				<p class="text-slate-400 text-sm">{$_('technology.agents.wellness.desc')}</p>
+				<h5 class="text-gray-900 font-semibold mb-1">{$_('technology.agents.wellness.title')}</h5>
+				<p class="text-gray-600 text-sm">{$_('technology.agents.wellness.desc')}</p>
 			</div>
 			<div class="glass rounded-xl p-5">
 				<div class="flex items-center gap-2 mb-3">
-					<span class="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></span>
-					<span class="text-xs text-emerald-400 font-medium">{$_('technology.agents.live')} · Constanza</span>
+					<span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+					<span class="text-xs text-emerald-600 font-medium">{$_('technology.agents.live')} · Constanza</span>
 				</div>
-				<h5 class="text-white font-semibold mb-1">{$_('technology.agents.fiscal.title')}</h5>
-				<p class="text-slate-400 text-sm">{$_('technology.agents.fiscal.desc')}</p>
+				<h5 class="text-gray-900 font-semibold mb-1">{$_('technology.agents.fiscal.title')}</h5>
+				<p class="text-gray-600 text-sm">{$_('technology.agents.fiscal.desc')}</p>
 			</div>
 			<div class="glass rounded-xl p-5">
 				<div class="flex items-center gap-2 mb-3">
-					<span class="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></span>
-					<span class="text-xs text-emerald-400 font-medium">{$_('technology.agents.live')} · Agora</span>
+					<span class="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
+					<span class="text-xs text-emerald-600 font-medium">{$_('technology.agents.live')} · Agora</span>
 				</div>
-				<h5 class="text-white font-semibold mb-1">{$_('technology.agents.legal.title')}</h5>
-				<p class="text-slate-400 text-sm">{$_('technology.agents.legal.desc')}</p>
+				<h5 class="text-gray-900 font-semibold mb-1">{$_('technology.agents.legal.title')}</h5>
+				<p class="text-gray-600 text-sm">{$_('technology.agents.legal.desc')}</p>
 			</div>
 		</div>
 	</div>
@@ -223,13 +222,13 @@
 <!-- Integrations -->
 <section class="py-12 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-7xl mx-auto">
-		<h3 class="text-2xl font-bold text-white mb-6">{$_("technology.sections.integrations")}</h3>
+		<h3 class="text-2xl font-bold text-gray-900 mb-6">{$_("technology.sections.integrations")}</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 			{#each techStackKeys.integrations as tech}
-				<div class="glass rounded-xl p-5 hover:border-blue-500/50 transition-all">
+				<div class="glass rounded-xl p-5 hover:border-gray-900 transition-all">
 					<div class="text-2xl mb-2">{tech.icon}</div>
-					<h4 class="text-white font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
-					<p class="text-slate-400 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
+					<h4 class="text-gray-900 font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
+					<p class="text-gray-600 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
 				</div>
 			{/each}
 		</div>
@@ -239,13 +238,13 @@
 <!-- Infrastructure -->
 <section class="py-12 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-7xl mx-auto">
-		<h3 class="text-2xl font-bold text-white mb-6">{$_("technology.sections.infrastructure")}</h3>
+		<h3 class="text-2xl font-bold text-gray-900 mb-6">{$_("technology.sections.infrastructure")}</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 			{#each techStackKeys.infrastructure as tech}
-				<div class="glass rounded-xl p-5 hover:border-cyan-500/50 transition-all">
+				<div class="glass rounded-xl p-5 hover:border-gray-900 transition-all">
 					<div class="text-2xl mb-2">{tech.icon}</div>
-					<h4 class="text-white font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
-					<p class="text-slate-400 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
+					<h4 class="text-gray-900 font-semibold">{$_(`technology.stack.${tech.key}.name`)}</h4>
+					<p class="text-gray-600 text-sm">{$_(`technology.stack.${tech.key}.description`)}</p>
 				</div>
 			{/each}
 		</div>
@@ -255,9 +254,9 @@
 <!-- CTA -->
 <section class="py-20 px-4 sm:px-6 lg:px-8">
 	<div class="max-w-3xl mx-auto text-center">
-		<h3 class="text-3xl font-bold text-white mb-4">{$_("technology.cta.title")}</h3>
-		<p class="text-slate-400 mb-8">{$_("technology.cta.subtitle")}</p>
-		<a href="/contacto" class="inline-flex px-8 py-4 bg-gradient-to-r from-emerald-500 to-cyan-600 text-white rounded-xl hover:from-emerald-600 hover:to-cyan-700 transition-all font-semibold">
+		<h3 class="text-3xl font-bold text-gray-900 mb-4">{$_("technology.cta.title")}</h3>
+		<p class="text-gray-600 mb-8">{$_("technology.cta.subtitle")}</p>
+		<a href="/contacto" class="inline-flex px-8 py-4 bg-black text-white rounded-xl hover:bg-gray-800 transition-all font-semibold">
 			{$_('technology.cta.button')}
 		</a>
 	</div>

--- a/src/routes/terminos/+page.svelte
+++ b/src/routes/terminos/+page.svelte
@@ -23,154 +23,154 @@
 <main class="py-16 px-4 sm:px-6 lg:px-8">
 	<article class="max-w-4xl mx-auto" use:scrollReveal>
 		<div class="mb-12">
-			<h1 class="text-4xl font-bold text-white mb-4">{$_('terms.title')}</h1>
-			<p class="text-slate-400">{$_('terms.lastUpdated')}: {$_('terms.date')}</p>
+			<h1 class="text-4xl font-bold text-gray-900 mb-4 tracking-tight">{$_('terms.title')}</h1>
+			<p class="text-gray-500">{$_('terms.lastUpdated')}: {$_('terms.date')}</p>
 		</div>
 
-		<div class="prose prose-invert prose-slate max-w-none space-y-8">
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section1.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+		<div class="prose prose-slate max-w-none space-y-8">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section1.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section1.content')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section2.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section2.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('terms.section2.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each serviceItems as item}
-						<li><strong class="text-white">{$_(`terms.section2.items.${item}.label`)}</strong> {$_(`terms.section2.items.${item}.desc`)}</li>
+						<li><strong class="text-gray-900">{$_(`terms.section2.items.${item}.label`)}</strong> {$_(`terms.section2.items.${item}.desc`)}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section3.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section3.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section3.p1')}
 				</p>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('terms.section3.p2')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section4.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section4.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('terms.section4.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each paymentItems as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('terms.section4.note')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section5.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section5.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('terms.section5.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each useItems as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section6.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section6.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section6.p1')}
 				</p>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('terms.section6.p2')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section7.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section7.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('terms.section7.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each availabilityItems as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section8.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section8.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('terms.section8.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each cfdiItems as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section9.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section9.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section9.p1')}
 				</p>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('terms.section9.p2')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section10.title')}</h2>
-				<p class="text-slate-300 leading-relaxed mb-4">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section10.title')}</h2>
+				<p class="text-gray-700 leading-relaxed mb-4">
 					{$_('terms.section10.intro')}
 				</p>
-				<ul class="list-disc list-inside text-slate-300 space-y-2">
+				<ul class="list-disc list-inside text-gray-700 space-y-2">
 					{#each cancelItems as item}
 						<li>{item}</li>
 					{/each}
 				</ul>
-				<p class="text-slate-300 leading-relaxed mt-4">
+				<p class="text-gray-700 leading-relaxed mt-4">
 					{$_('terms.section10.note')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section11.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section11.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section11.content')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section12.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section12.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section12.content')}
 				</p>
 			</section>
 
-			<section class="bg-slate-900 rounded-2xl border border-slate-800 p-8">
-				<h2 class="text-2xl font-bold text-white mb-4">{$_('terms.section13.title')}</h2>
-				<p class="text-slate-300 leading-relaxed">
+			<section class="bg-white rounded-2xl border border-gray-200 p-8">
+				<h2 class="text-2xl font-bold text-gray-900 mb-4">{$_('terms.section13.title')}</h2>
+				<p class="text-gray-700 leading-relaxed">
 					{$_('terms.section13.intro')}
 				</p>
-				<div class="mt-4 text-slate-300">
-					<p><strong class="text-white">Red Broom Software S.A.S. de C.V.</strong></p>
+				<div class="mt-4 text-gray-700">
+					<p><strong class="text-gray-900">Red Broom Software S.A.S. de C.V.</strong></p>
 					<p>{$_('terms.section13.location')}</p>
-					<p>Email: <a href="mailto:dia@redbroomsoftware.com" class="text-blue-400 hover:text-blue-300">dia@redbroomsoftware.com</a></p>
+					<p>Email: <a href="mailto:dia@redbroomsoftware.com" class="text-gray-900 underline hover:text-gray-600">dia@redbroomsoftware.com</a></p>
 				</div>
 			</section>
 
-			<section class="bg-blue-900/20 rounded-2xl border border-blue-500/30 p-8">
-				<p class="text-slate-300 leading-relaxed text-center">
+			<section class="bg-gray-50 rounded-2xl border border-gray-200 p-8">
+				<p class="text-gray-700 leading-relaxed text-center">
 					{$_('terms.acceptance')}
 				</p>
 			</section>


### PR DESCRIPTION
Fourth + final public surface of the S427 unified front-door (Chunk 2). Re-skins the apex marketing site from dark-glassmorphic → **light Palacio** and mounts the shared cross-surface `SiteHeader`/`SiteFooter` (palacio-ui ^0.1.0). Now all four surfaces (apex/palacio/patadas/hub) share one bar + one aesthetic.

**Scope:** 17 files — app.css (glassmorphism→light cards, light scrollbar), +layout (light root + SiteHeader/SiteFooter wired to svelte-i18n), 8 content pages dark→light, 4 components re-skinned. **Functionality preserved:** i18n catalog/keys unchanged (no copy rewrite — 4-function copy is a separate Brillo decision), /plataformas live Camino pricing, /contacto form+reCAPTCHA, scroll-reveal, all links. **Verified:** prod build green; svelte-check 14 errors (all pre-existing on master, 0 new). money-path=N, **deploy Brillo-gated**.

**⚠️ Visual QA before deploy (re-skin was done without a browser — eyeball these):** (1) home hero is now plain on white — consider the Palacio black hero-bar; (2) ecosystem grid color swatches left vivid vs the monochrome palette; (3) /plataformas pricing cards flattened to gray — check card separation; (4) SiteHeader mobile nav collapses (hamburger sheet is a palacio-ui v0.1.x follow-up); (5) interior pages are systematic class-conversions — spacing/contrast on white unverified visually. Kept both the rich per-page Footer (legal/ecosystem links) AND SiteFooter; dead Header.svelte/LanguageSwitcher left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)