### PR TITLE
fix(apex): remove redundant SiteFooter — keep rich marketing footer (S434 polish)

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { getStoredLocale, setLocale } from '$lib/i18n';
 	import { onMount } from 'svelte';
 	import { _, locale } from 'svelte-i18n';
-	import { SiteHeader, SiteFooter } from '@r-bsoftware/palacio-ui';
+	import { SiteHeader } from '@r-bsoftware/palacio-ui';
 
 	let { children } = $props();
 
@@ -40,5 +40,6 @@
 	<main id="main" class="flex-1">
 		{@render children()}
 	</main>
-	<SiteFooter surface="rbs" locale={shellLocale} />
+	<!-- Footer is rendered per-page (rich marketing Footer in $lib/components/Footer.svelte).
+	     The minimal palacio-ui SiteFooter was removed here to avoid a double footer (S434). -->
 </div>


### PR DESCRIPTION
Apex rendered both its rich per-page Footer AND the minimal palacio-ui SiteFooter (layout) → double footer at the bottom (seen in S434 mobile QA). Per Brillo's call, keep the content-rich marketing footer and drop the redundant SiteFooter from the layout. SiteHeader unchanged (header stays unified). money-path=N, Brillo-gated deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)